### PR TITLE
Feat resizable plots

### DIFF
--- a/src/components/AppPlot.jsx
+++ b/src/components/AppPlot.jsx
@@ -17,12 +17,25 @@ class AppPlotCaption extends React.Component {
 }
 
 export default class PlotlyComponent extends React.Component {
+
+  componentDidMount () {
+    this.resizeObserver = new ResizeObserver(entries => {
+      for (let entry of entries) {
+        window.Plotly.Plots.resize(entry.target);
+      }
+    });
+    this.resizeObserver.observe(this.plot.el);
+  }
+
+  componentWillUnmount () {
+    this.resizeObserver.unobserve(this.plot.el);
+  }
+
   render () {
     return (
-      <figure
-        className={this.props.className}
-      >
+      <figure className={this.props.className} >
         <Plot
+          ref={ ref => this.plot = ref }
           { ...this.props.plot }
         />
         {

--- a/src/layout/AppLayout.jsx
+++ b/src/layout/AppLayout.jsx
@@ -78,7 +78,7 @@ class AppLayout extends React.Component {
         </div>
 
         {/* PAGE CONTENT */}
-        <div className="relative md:ml-64">
+        <div className="relative md:ml-64 min-h-screen bg-gray-300">
 
           {/* ROUTES */}
           { this.props.children }

--- a/src/modules/data/components/GroupItem.jsx
+++ b/src/modules/data/components/GroupItem.jsx
@@ -22,8 +22,8 @@ const GroupItemStat = (props) => {
 
   return (
     <div className={`flex mt-1 text-sm ${props.className}`}>
-      <span className="text-gray-500">{ label }</span>
-      <span className="ml-1 text-gray-600">{ value }</span>
+      <span className="text-gray-700 font-bold">{ label }</span>
+      <span className="ml-1 text-gray-800">{ value }</span>
     </div>
   );
 };
@@ -60,20 +60,17 @@ export default class GroupItem extends React.Component {
   render () {
     return (
       <div className={
-        `flex items-center mb-6 p-6
-       shadow-lg
-       bg-blue-200 hover:bg-blue-300
-       ${this.props.className}`
+        `flex items-center p-6 shadow-lg bg-white ${this.props.className}`
       }>
 
         <div className="w-full" >
 
           <h2 className="text-lg text-gray-800">{ this.props.group.name }</h2>
 
-          <div className="flex mt-2" >
+          <div className="sm:flex mt-2" >
             <GroupItemStat label="Units:" value={ this.props.group.countUnit } />
-            <GroupItemStat className="ml-4" label="Samples:" value={ this.props.group.samples.length } />
-            <GroupItemStat className="ml-4" label="Replicates:" value={ this.groupReplicates } />
+            <GroupItemStat className="sm:ml-4" label="Samples:" value={ this.props.group.samples.length } />
+            <GroupItemStat className="sm:ml-4" label="Replicates:" value={ this.groupReplicates } />
           </div>
 
         </div>

--- a/src/modules/data/layout/DataLayout.jsx
+++ b/src/modules/data/layout/DataLayout.jsx
@@ -6,7 +6,7 @@ export default class HomeLayout extends React.Component {
   render () {
 
     return (
-      <main className="flex justify-center mt-10 mr-6 px-6 md:px-12 w-full" >
+      <main className="flex justify-center mr-6 py-10 px-6 md:px-12 w-full" >
 
         { this.props.children }
 

--- a/src/modules/data/pages/DataView.jsx
+++ b/src/modules/data/pages/DataView.jsx
@@ -32,6 +32,7 @@ export default class DataView extends React.Component {
           store.groups.map((group, index) => (
 
             <GroupItem
+              className="mt-6 first:mt-0"
               key={ `${group.name}-${index}`}
               group={ group }
               groupIndex={ index }

--- a/src/modules/plotly/layout/PlotsLayout.jsx
+++ b/src/modules/plotly/layout/PlotsLayout.jsx
@@ -10,7 +10,7 @@ export default class PlotsLayout extends React.Component {
       <div className="flex flex-col xl:flex-row max-w-screen">
         {/* MAIN CONTENT: ROUTES */}
 
-        <main className="flex flex-wrap" >
+        <main className="flex flex-wrap w-full" >
           {/* PRELOADED IMAGE
 
             This <img/> element is pre-styled to integrate with the existing layout as
@@ -41,7 +41,9 @@ export default class PlotsLayout extends React.Component {
 
           */}
           {store.image && (
-            <div className="flex justify-center items-center m-3 resize-x overflow-auto shadow-outer bg-white">
+            <div className="flex justify-center items-center m-3 w-full
+                            resize-x overflow-auto shadow-outer bg-white"
+            >
               <img src={store.image} />
             </div>
           )}

--- a/src/modules/plotly/layout/PlotsLayout.jsx
+++ b/src/modules/plotly/layout/PlotsLayout.jsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React from 'react';
 
-import { store } from "@/store";
-import { observer } from "mobx-react";
+import { store } from '@/store';
+import { observer } from 'mobx-react';
 
 @observer
 export default class PlotsLayout extends React.Component {
@@ -10,10 +10,7 @@ export default class PlotsLayout extends React.Component {
       <div className="flex flex-col xl:flex-row max-w-screen">
         {/* MAIN CONTENT: ROUTES */}
 
-        <main
-          className="flex flex-col items-center p-6 w-full h-full
-                     xl:flex-row xl:flex-wrap xl:justify-center xl:items-center"
-        >
+        <main className="flex flex-wrap" >
           {/* PRELOADED IMAGE
 
             This <img/> element is pre-styled to integrate with the existing layout as
@@ -44,7 +41,7 @@ export default class PlotsLayout extends React.Component {
 
           */}
           {store.image && (
-            <div className="flex justify-center items-center mt-10 w-full">
+            <div className="flex justify-center items-center m-3 resize-x overflow-auto shadow-outer bg-white">
               <img src={store.image} />
             </div>
           )}

--- a/src/modules/plotly/pages/PlotsView.jsx
+++ b/src/modules/plotly/pages/PlotsView.jsx
@@ -12,7 +12,7 @@ export default class PlotlyComponent extends React.Component {
       store.plots.map((plot, index) => (
         <AppPlot
           key={`${plot?.layout?.title?.text}-${index}`}
-          className="relative flex flex-col m-3 py-6 resize-x shadow-outer overflow-auto bg-white"
+          className="relative flex flex-col m-3 py-6 w-full resize-x shadow-outer overflow-auto bg-white"
           plot={{ ...plot }}
           showCaption={plot.showCaption}
           accessions={plot.accessions}

--- a/src/modules/plotly/pages/PlotsView.jsx
+++ b/src/modules/plotly/pages/PlotsView.jsx
@@ -12,7 +12,7 @@ export default class PlotlyComponent extends React.Component {
       store.plots.map((plot, index) => (
         <AppPlot
           key={`${plot?.layout?.title?.text}-${index}`}
-          className="relative flex flex-col mt-10 w-full"
+          className="relative flex flex-col m-3 py-6 resize-x shadow-outer overflow-auto bg-white"
           plot={{ ...plot }}
           showCaption={plot.showCaption}
           accessions={plot.accessions}

--- a/src/utils/plotsHelper.js
+++ b/src/utils/plotsHelper.js
@@ -149,8 +149,6 @@ export function createGroupPlot (plotData, accessionIds, showlegend, showCaption
   let data = [];
   let line = null;
   let showLegendCurve = null;
-  console.log(accessionIds);
-  console.log(plotData);
   accessionIds.forEach((accession, accessionIndex) => {
     if(accessionIds.length > 1) {
       line = {
@@ -159,7 +157,6 @@ export function createGroupPlot (plotData, accessionIds, showlegend, showCaption
     }
     Object.keys(plotData).forEach((group,groupIndex) => {
       showLegendCurve = accessionIds.length > 1 ? (groupIndex > 0 ? false : true) : true;
-      console.log(`${groupIndex} ${accessionIndex} ${showLegendCurve}`);
       data.push(createPlotGroup(plotData, group, plotType, accession, line, showLegendCurve));
     });
   });


### PR DESCRIPTION
## Issue

Closes #23.

## Description

This PR makes the image and plot elements resizable on the horizontal axis.

- Image and plot containers use the CSS `resize` property.
- Plots are instructed to resize via the `ResizeObserver` API.
- Plots use the `autosize` and `responsive` properties to adjust their dimensions on container and window resize events, respectively.

## Changes in this PR

- Plots layout as a flex-wrap container.
- Image and plots are resizable on the horizontal axis and have a default full-width in the initial render.
- A grey background has been added to the main layout, to better highlight data, image, and plot cards


## Notes

- The `ResizeObserver` API is supported in most modern browsers, but it won't work in Internet Explorer (any version). More information in [caniuse](https://caniuse.com/resizeobserver),
- This PR likely supersedes #22.
