### PR TITLE
feat: gene browser details window

### DIFF
--- a/src/assets/svg/hero-icons.svg
+++ b/src/assets/svg/hero-icons.svg
@@ -46,6 +46,11 @@
     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/>
   </symbol>
 
+  <symbol id="eye" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+  </symbol>
+
   <symbol id="home" fill="currentColor" viewBox="0 0 20 20">
     <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z"/>
   </symbol>

--- a/src/components/AppModal2.jsx
+++ b/src/components/AppModal2.jsx
@@ -10,24 +10,22 @@ export default class AppModal extends React.Component {
     super();
   }
 
-  hideModal = () => this.setState({ showModal: false })
-
   render () {
 
     return (
       this.props.showModal &&
       <AppOverlay
-        className="shadow-lg rounded-lg bg-white"
+        className={ `shadow-lg rounded-lg bg-white ${ this.props.className ?? '' }`}
         overlayClass="bg-black"
         onClick={ this.props.hideModal }
       >
 
         {/* HEADER */}
         <div
-          className="flex items-center justify-between px-6 pb-2 mt-5 rounded-t text-gray-800"
+          className="flex items-center justify-between p-6 rounded-t text-gray-800"
         >
 
-          <h2 className="uppercase w-full text-center text-xl md:text-2xl font-semibold">
+          <h2 className="uppercase w-full text-center text-base sm:text-xl md:text-2xl font-semibold">
             { this.props.title }
           </h2>
 

--- a/src/components/AppOverlay.jsx
+++ b/src/components/AppOverlay.jsx
@@ -14,7 +14,7 @@ export default class AppOverlay extends React.Component {
       <>
         {/* CONTAINER */}
         <div
-          className="fixed inset-0 z-40
+          className="fixed z-40 inset-0
                      flex justify-center items-center
                      outline-none focus:outline-none"
         >

--- a/src/modules/tools/components/GeneDetails.jsx
+++ b/src/modules/tools/components/GeneDetails.jsx
@@ -1,0 +1,59 @@
+import React, { Component } from 'react';
+import { store } from '@/store';
+
+export default class GeneDetails extends Component {
+
+  constructor (props) {
+    super(props);
+    this.geneDetails = this.composeGeneDetails(props.accessionId);
+  }
+
+  composeGeneDetails = (accessionId) => {
+
+    const results = store.groups.reduce((details, group) => {
+
+      group.samples.forEach(sample => {
+
+        sample.replicates.forEach((counts, index) => {
+
+          details.push({
+            group: group.name,
+            sample: sample.name,
+            replicate: index,
+            count: counts[accessionId],
+          });
+
+        });
+
+      });
+
+      return details;
+
+    }, []);
+    return results;
+
+  }
+
+  render() {
+    return (
+      <div className="flex flex-col flex-auto max-h-3xl overflow-auto">
+        {
+          this.geneDetails &&
+          this.geneDetails.map(({ group, sample, replicate, count }) => (
+
+            <div
+              className="flex p-5 odd:bg-gray-100 hover:bg-yellow-100"
+              key={ `${group}-${sample}-${replicate}` }
+            >
+              <div className="px-5 w-2/6">{ group }</div>
+              <div className="px-5 w-2/6">{ sample }</div>
+              <div className="px-5 w-1/6 text-center">{ replicate }</div>
+              <div className="px-5 w-1/6 text-center">{ count }</div>
+            </div>
+
+          ))
+        }
+      </div>
+    );
+  }
+}

--- a/src/modules/tools/components/GeneDetails.jsx
+++ b/src/modules/tools/components/GeneDetails.jsx
@@ -36,7 +36,13 @@ export default class GeneDetails extends Component {
 
   render() {
     return (
-      <div className="flex flex-col flex-auto max-h-3xl overflow-auto">
+      <div className="flex flex-col flex-auto overflow-hidden overflow-y-scroll">
+        <div className="flex p-5 font-semibold bg-yellow-200 uppercase">
+          <div className="px-5 w-2/6">Group</div>
+          <div className="px-5 w-2/6">Sample</div>
+          <div className="px-5 w-1/6 text-center">Replicate</div>
+          <div className="px-5 w-1/6 text-center">Count</div>
+        </div>
         {
           this.geneDetails &&
           this.geneDetails.map(({ group, sample, replicate, count }) => (

--- a/src/modules/tools/pages/GeneBrowser.jsx
+++ b/src/modules/tools/pages/GeneBrowser.jsx
@@ -3,11 +3,17 @@ import { autorun } from 'mobx';
 import { store } from '@/store';
 import { escapeRegExp } from '@/utils/validation';
 
+import AppModal from '@/components/AppModal2';
 import AppNumber from '@/components/AppNumber';
 import AppSelect from '@/components/AppSelect';
 import AppText from '@/components/AppText';
 
+import GeneDetails from '../components/GeneDetails';
+import AppIcon from '@/components/AppIcon';
+import AppButton from '@/components/AppButton';
+
 export default class GeneBrowser extends Component {
+
   constructor () {
     super();
     this.state = {
@@ -16,6 +22,7 @@ export default class GeneBrowser extends Component {
       pageOffset: 1,
       pageMax: 1,
       countView: 20,
+      showGeneDetails: false,
     };
   }
 
@@ -115,6 +122,16 @@ export default class GeneBrowser extends Component {
 
   }
 
+  /* ACTIONS */
+
+  /**
+   * Toggle the gene details modal visibility.
+   * @param {React.MouseEvent<HTMLDivElement>} event
+   */
+  toggleGeneDetails = (accessionId) => {
+    this.setState({ showGeneDetails: accessionId });
+  }
+
   /* RENDER */
 
   render() {
@@ -159,21 +176,43 @@ export default class GeneBrowser extends Component {
 
         </div>
 
-        <div className="bg-white mt-6 p-6">
+        <div className="bg-white mt-6">
           {
             this.state.geneView.map(({ accessionId, description }) => (
 
               <div
-                className="py-3"
+                className="group flex items-center p-6 border border-transparent hover:bg-yellow-100 odd:bg-gray-100"
                 key={ accessionId }
+                onDoubleClick={ () => this.toggleGeneDetails(accessionId) }
               >
-                <div className="font-bold">{ accessionId }</div>
-                <div className="mx-6">{ description ?? 'No description exists for this gene.' }</div>
+
+                <div className="w-full">
+                  <div className="font-bold">{ accessionId }</div>
+                  <div className="mx-6">{ description ?? 'No description exists for this gene.' }</div>
+                </div>
+
+                <AppButton onClick={ () => this.toggleGeneDetails(accessionId) } >
+                  <AppIcon
+                    className="ml-4 w-6 h-6 text-gray-500 invisible group-hover:visible"
+                    file="hero-icons"
+                    id="eye"
+                  />
+                </AppButton>
+
               </div>
 
             ))
           }
         </div>
+
+        <AppModal
+          className="w-11/12 sm:w-3/4 md:w-11/12 2xl:w-1/2"
+          title={ this.state.showGeneDetails }
+          showModal={ this.state.showGeneDetails }
+          hideModal={ () => this.toggleGeneDetails(false) }
+        >
+          <GeneDetails accessionId={ this.state.showGeneDetails } />
+        </AppModal>
 
       </div>
     );

--- a/src/modules/tools/pages/GeneBrowser.jsx
+++ b/src/modules/tools/pages/GeneBrowser.jsx
@@ -206,7 +206,7 @@ export default class GeneBrowser extends Component {
         </div>
 
         <AppModal
-          className="w-11/12 sm:w-3/4 md:w-11/12 2xl:w-1/2"
+          className="flex flex-col w-full h-full md:w-5/6 md:h-5/6 lg:w-3/4 2xl:w-1/2"
           title={ this.state.showGeneDetails }
           showModal={ this.state.showGeneDetails }
           hideModal={ () => this.toggleGeneDetails(false) }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,7 +18,10 @@ module.exports = {
   },
   variants: {
     extend: {
-      margin: ['first']
+      backgroundColor: ['odd'],
+      borderWidth: ['first'],
+      margin: ['first'],
+      visibility: ['group-hover'],
     }
   }
 };


### PR DESCRIPTION
## Issue

None yet.

## Description

This PR adds a new **Gene Browser** modal window that shows detailed _data_ information about the currently selected gene.

## Changes

### Styles

- Added `tailwindcss` variants to support `first`, `odd`, and `group-hover` modifiers necessary for the new component.
- Tweaked the `AppModal` component header to better complement its size and positioning with different screens and sibling components.
- Added a root `className` property to the `AppModal` component.
- Improved height-width response of the modal to different screen sizes.

### Features

- Add a new `GeneDetails.jsx` component to how selected gene data information. This component is displayed within a modal controlled in `GeneBrowser.jsx`.

### Pending (new PR)

- Header row should be fixed at the top of the Gene Details modal window.
- The AppModal2 component should be refactored to not wrap a container class around the children (i.e. control the children directly via their own class).
