### PR TITLE
feat: gene card

### DIFF
--- a/src/components/cards/GeneCard.jsx
+++ b/src/components/cards/GeneCard.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+export default function GeneCard({ color, accession, geneInfo, ...props }) {
+  return (
+    <div className={props.className}>
+      <div className="flex items-center mb-4">
+        <div
+          className={`font-semibold text-lg ${props.className}`}
+          style={{ color: color ?? '' }}
+        >
+          {accession}
+        </div>
+        {props.actions}
+      </div>
+      {geneInfo.size > 0
+        ? [...geneInfo.entries()].map(([colName, cellValue]) => (
+            <div key={`${accession}-${colName}`} className="flex">
+              <div className="flex flex-shrink-0 ml-2 py-1 w-36 uppercase text-yellow-700">
+                {colName}
+              </div>
+              <div className="flex ml-5 py-1 break-all">{cellValue}</div>
+            </div>
+          ))
+        : 'No information available for this gene.'}
+    </div>
+  );
+}

--- a/src/modules/plotly/components/PlotCaption.jsx
+++ b/src/modules/plotly/components/PlotCaption.jsx
@@ -9,9 +9,12 @@ export default class PlotCaption extends React.Component {
       <PlotContext.Consumer>
         {({ hoveredGene }) => (
           <figcaption
-            className={`flex flex-col py-5 mt-2 mx-8
-                 border-t-2 hover:border-yellow-600
-                 hover:bg-yellow-100
+            className={`
+                 flex py-5
+                 hover:bg-yellow-100 odd:bg-gray-100
+                 text-justify text-gray-800 text-sm ${
+                   this.props.className ?? ''
+                 }
                  ${
                    hoveredGene && !hoveredGene.includes(this.props.accession)
                      ? 'opacity-50'
@@ -22,7 +25,7 @@ export default class PlotCaption extends React.Component {
                      ? 'bg-yellow-100'
                      : ''
                  }
-                 text-justify text-gray-800 text-sm`}
+                 `}
             style={{ borderColor: this.props.color ?? '' }}
           >
             <GeneCard

--- a/src/modules/plotly/components/PlotCaption.jsx
+++ b/src/modules/plotly/components/PlotCaption.jsx
@@ -1,61 +1,38 @@
 import React from 'react';
 
+import GeneCard from '@/components/cards/GeneCard';
 import { PlotContext } from './PlotlyPlot';
 
 export default class PlotCaption extends React.Component {
   render() {
     return (
       <PlotContext.Consumer>
-        {
-          ({ hoveredGene }) => (
-            <figcaption
-              className={
-                `flex flex-col py-5 mt-2
+        {({ hoveredGene }) => (
+          <figcaption
+            className={`flex flex-col py-5 mt-2 mx-8
                  border-t-2 hover:border-yellow-600
                  hover:bg-yellow-100
-                 ${hoveredGene && !hoveredGene.includes(this.props.accession) ? 'opacity-50' : ''}
-                 ${hoveredGene.includes(this.props.accession) ? 'bg-yellow-100' : ''}
-                 text-justify text-gray-800 text-sm`
-              }
-              style={{ borderColor: this.props.color ?? '' }}
-            >
-
-              <div
-                className="font-semibold text-base"
-                style={{ color: this.props.color ?? '' }}
-              >
-                { this.props.accession }
-              </div>
-
-              <div className="flex items-center mt-2">
-
-                <div>
-                  {
-                    [ ...this.props.caption.keys() ].map(colName => (
-                      <div
-                        key={ colName }
-                        className="ml-2 py-1 uppercase text-yellow-700"
-                      >
-                        { colName }
-                      </div>
-                    ))
-                  }
-                </div>
-
-                <div>
-                  {
-                    [ ...this.props.caption.values() ].map((cellValue, index) => (
-                      <div key={ index } className="ml-5 py-1">
-                        { cellValue }
-                      </div>
-                    ))
-                  }
-                </div>
-
-              </div>
-            </figcaption>
-          )
-        }
+                 ${
+                   hoveredGene && !hoveredGene.includes(this.props.accession)
+                     ? 'opacity-50'
+                     : ''
+                 }
+                 ${
+                   hoveredGene.includes(this.props.accession)
+                     ? 'bg-yellow-100'
+                     : ''
+                 }
+                 text-justify text-gray-800 text-sm`}
+            style={{ borderColor: this.props.color ?? '' }}
+          >
+            <GeneCard
+              className="px-2"
+              accession={this.props.accession}
+              geneInfo={this.props.caption}
+              color={this.props.color}
+            />
+          </figcaption>
+        )}
       </PlotContext.Consumer>
     );
   }

--- a/src/modules/plotly/components/PlotlyPlot.jsx
+++ b/src/modules/plotly/components/PlotlyPlot.jsx
@@ -1,4 +1,3 @@
-
 import React, { createContext } from 'react';
 import createPlotlyComponent from 'react-plotly.js/factory';
 
@@ -8,16 +7,15 @@ const Plot = createPlotlyComponent(Plotly);
 export const PlotContext = createContext({ hoveredGene: '' });
 
 export default class PlotlyPlot extends React.Component {
-
-  constructor () {
+  constructor() {
     super();
     this.state = {
-      name: ''
+      name: '',
     };
   }
 
-  componentDidMount () {
-    this.resizeObserver = new ResizeObserver(entries => {
+  componentDidMount() {
+    this.resizeObserver = new ResizeObserver((entries) => {
       for (let entry of entries) {
         window.Plotly.Plots.resize(entry.target);
       }
@@ -25,7 +23,7 @@ export default class PlotlyPlot extends React.Component {
     this.resizeObserver.observe(this.plot.el);
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     this.resizeObserver.unobserve(this.plot.el);
   }
 
@@ -34,25 +32,23 @@ export default class PlotlyPlot extends React.Component {
     if (points.length !== 1 || this.props.plot.accessions.length <= 1) return;
     const name = points[0].fullData.name;
     this.setState({ name });
-  }
+  };
 
   onPlotUnhover = () => {
     this.setState({ name: '' });
-  }
+  };
 
-  render () {
+  render() {
     return (
       <PlotContext.Provider value={{ hoveredGene: this.state.name }}>
-        <figure className={this.props.className} >
+        <figure className={this.props.className}>
           <Plot
-            onHover={ this.onPlotHover }
-            onUnhover={ this.onPlotUnhover }
-            ref={ ref => this.plot = ref }
-            { ...this.props.plot }
+            onHover={this.onPlotHover}
+            onUnhover={this.onPlotUnhover}
+            ref={(ref) => (this.plot = ref)}
+            {...this.props.plot}
           />
-          <div className="flex flex-wrap gap-x-10 mx-20">
-            { this.props.children }
-          </div>
+          {this.props.children}
         </figure>
       </PlotContext.Provider>
     );

--- a/src/modules/plotly/components/PlotlyPlot.jsx
+++ b/src/modules/plotly/components/PlotlyPlot.jsx
@@ -48,7 +48,7 @@ export default class PlotlyPlot extends React.Component {
             ref={(ref) => (this.plot = ref)}
             {...this.props.plot}
           />
-          {this.props.children}
+          <div className="mx-12">{this.props.children}</div>
         </figure>
       </PlotContext.Provider>
     );

--- a/src/modules/plotly/pages/PlotsView.jsx
+++ b/src/modules/plotly/pages/PlotsView.jsx
@@ -1,38 +1,33 @@
-import React        from 'react';
+import React from 'react';
 import { observer } from 'mobx-react';
 
-import PlotlyPlot  from '../components/PlotlyPlot';
+import PlotlyPlot from '../components/PlotlyPlot';
 import PlotCaption from '../components/PlotCaption';
 
 import { plotStore } from '@/store/plot-store';
 import { infoTable } from '@/store/data-store';
-import { colors }    from '@/utils/plotsHelper';
+import { colors } from '@/utils/plotsHelper';
 
 @observer
 export default class PlotsView extends React.Component {
-
   render() {
-    return (
-      plotStore.plots.map(plot => (
-        <PlotlyPlot
-          key={plot.plotId}
-          className="relative flex flex-col m-3 py-6 w-full resize-x
+    return plotStore.plots.map((plot) => (
+      <PlotlyPlot
+        key={plot.plotId}
+        className="relative flex flex-col m-3 py-6 w-full resize-x
                      shadow-outer overflow-auto bg-white"
-          plot={{ ...plot }}
-        >
-          {
-            plot.showCaption &&
-            plot.accessions.map((accession, index) => (
-              <PlotCaption
-                key={ `accession-${index}` }
-                accession={ accession }
-                caption={ infoTable.getRowAsMap(accession) }
-                color={ plot.accessions.length > 1  ? colors[index] : null }
-              />
-            ))
-          }
-        </PlotlyPlot>
-      ))
-    );
+        plot={{ ...plot }}
+      >
+        {plot.showCaption &&
+          plot.accessions.map((accession, index) => (
+            <PlotCaption
+              key={`${accession}-${index}`}
+              accession={accession}
+              caption={infoTable.getRowAsMap(accession)}
+              color={plot.accessions.length > 1 ? colors[index] : null}
+            />
+          ))}
+      </PlotlyPlot>
+    ));
   }
 }

--- a/src/modules/tools/components/GeneDetails.jsx
+++ b/src/modules/tools/components/GeneDetails.jsx
@@ -8,7 +8,9 @@ export default class GeneDetails extends Component {
           <div className="px-5 w-4/12">Group</div>
           <div className="px-5 w-3/12">Sample</div>
           <div className="px-5 w-2/12">Replicate</div>
-          <div className="px-5 w-3/12 text-right">Count [raw]</div>
+          <div className="px-5 w-3/12 text-right">
+            Count [{this.props.countUnit}]
+          </div>
         </div>
         {this.props.geneCounts.map(({ group, sample, replicate, count }) => (
           <div

--- a/src/modules/tools/pages/GeneBrowser.jsx
+++ b/src/modules/tools/pages/GeneBrowser.jsx
@@ -1,25 +1,23 @@
 import React, { Component } from 'react';
 
 import { autorun } from 'mobx';
-import {
-  dataTable,
-  infoTable
-} from '@/store/data-store';
+import { dataTable, infoTable } from '@/store/data-store';
+import { settings } from '@/store/settings';
 
-import { escapeRegExp }  from '@/utils/string';
+import { escapeRegExp } from '@/utils/string';
 
 import AppButton from '@/components/AppButton';
-import AppIcon   from '@/components/AppIcon';
-import AppModal  from '@/components/AppModal2';
+import AppIcon from '@/components/AppIcon';
+import AppModal from '@/components/AppModal2';
 import AppNumber from '@/components/AppNumber';
 import AppSelect from '@/components/AppSelect';
-import AppText   from '@/components/AppText';
+import AppText from '@/components/AppText';
 
 import GeneDetails from '../components/GeneDetails';
+import GeneCard from '@/components/cards/GeneCard';
 
 export default class GeneBrowser extends Component {
-
-  constructor () {
+  constructor() {
     super();
     this.state = {
       geneView: [],
@@ -36,61 +34,60 @@ export default class GeneBrowser extends Component {
   /* AUXILIARY */
 
   computeGeneView = () => {
-
     // Retrieve gene information matching the search parameters (empty search matches all)
-    const regexp = new RegExp( escapeRegExp(this.state.searchId), 'i' );
+    const regexp = new RegExp(escapeRegExp(this.state.searchId), 'i');
     const matchingResults = dataTable.rowNames.reduce((matches, accession) => {
-
       // Match text in the accessions ids
       const accessionMatch = accession.search(regexp) > -1;
 
       // Match text in the info fields
       const geneInfo = infoTable.getRowAsMap(accession) ?? new Map();
       const infoMatch = geneInfo
-        ? Array.from(geneInfo.values()).some(field => field.search(regexp) > -1)
+        ? Array.from(geneInfo.values()).some(
+            (field) => field.search(regexp) > -1
+          )
         : false;
 
       // Include in the results if any matches are found
-      if (accessionMatch || infoMatch) matches.push({
-        accession,
-        geneInfo
-      });
+      if (accessionMatch || infoMatch)
+        matches.push({
+          accession,
+          geneInfo,
+        });
 
       return matches;
-
     }, []);
-
 
     // Calculate the current page view
     const countView = parseInt(this.state.countView);
-    const start = (this.state.pageOffset-1) * countView;
+    const start = (this.state.pageOffset - 1) * countView;
     const end = this.state.pageOffset * countView;
     const geneView = matchingResults.slice(start, end);
 
     // Calculate the number of pages according to the current display options
-    const pageMax = Math.ceil(matchingResults.length / this.state.countView) || 1;
+    const pageMax =
+      Math.ceil(matchingResults.length / this.state.countView) || 1;
 
-    this.setState(({ geneView, pageMax }));
-  }
+    this.setState({ geneView, pageMax });
+  };
 
   /* LYFECYCLE */
 
-  componentDidMount () {
-    this.disposeGeneViewListener = autorun( this.computeGeneView );
+  componentDidMount() {
+    this.disposeGeneViewListener = autorun(this.computeGeneView);
   }
 
-  componentDidUpdate (prevProps, prevState) {
-
-    if( prevState.searchId !== this.state.searchId
-        || prevState.pageOffset !== this.state.pageOffset
-        || prevState.countView !== this.state.countView
+  componentDidUpdate(prevProps, prevState) {
+    if (
+      prevState.searchId !== this.state.searchId ||
+      prevState.pageOffset !== this.state.pageOffset ||
+      prevState.countView !== this.state.countView
     ) {
       this.computeGeneView();
     }
-
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     this.disposeGeneViewListener();
   }
 
@@ -103,7 +100,7 @@ export default class GeneBrowser extends Component {
   onDisplayCountSelect = (event) => {
     const countView = event.target.value;
     this.setState({ countView });
-  }
+  };
 
   /**
    * Re-evaluate the captions result, including only accessions ids matching fully or
@@ -113,16 +110,15 @@ export default class GeneBrowser extends Component {
    */
   onGeneSearchSubmit = (event) => {
     if (event.key === 'Enter') {
-      this.setState({ pageOffset: 1, searchId: event.target.value});
+      this.setState({ pageOffset: 1, searchId: event.target.value });
     }
-  }
+  };
 
   /**
    * Update the _pageOffset_ state property.
    * @param {React.ChangeEvent<HTMLInputElement} event
    */
   onPageOffsetChange = (event) => {
-
     let pageOffset = event.target.value;
 
     if (pageOffset <= 0 || pageOffset > this.state.pageMax) {
@@ -130,8 +126,7 @@ export default class GeneBrowser extends Component {
     }
 
     this.setState({ pageOffset });
-
-  }
+  };
 
   /* ACTIONS */
 
@@ -143,48 +138,48 @@ export default class GeneBrowser extends Component {
     let selectedGeneCounts;
     if (selectedGene) {
       const table = dataTable.getRowAsMap(selectedGene, true);
-      selectedGeneCounts = [ ...table.entries() ].map(([ [ group, sample, replicate ], count]) => ({
-        group,
-        sample,
-        replicate,
-        count
-      }));
+      selectedGeneCounts = [...table.entries()].map(
+        ([[group, sample, replicate], count]) => ({
+          group,
+          sample,
+          replicate,
+          count,
+        })
+      );
     }
     this.setState({ selectedGene, selectedGeneCounts });
-  }
+  };
 
   /* RENDER */
 
   render() {
     return (
       <div className="m-6">
-
         <div className="mt-4 flex flex-col lg:flex-row bg-white px-6 py-5">
-
           <AppText
             className="lg:w-3/4 w-full"
             id="gene-browser-search"
             label="Search accession"
-            onKeyDown={ this.onGeneSearchSubmit }
+            onKeyDown={this.onGeneSearchSubmit}
           />
 
           <div className="flex flex-col flex-grow sm:flex-row">
             <AppNumber
               className="w-full mt-4 sm:w-1/2 lg:ml-3 lg:mt-0"
-              label={ `Page ${this.state.pageOffset}/${this.state.pageMax}`}
-              min={ 1 }
-              max={ this.state.pageMax }
-              required={ true }
-              value={ this.state.pageOffset }
-              onChange={ this.onPageOffsetChange }
+              label={`Page ${this.state.pageOffset}/${this.state.pageMax}`}
+              min={1}
+              max={this.state.pageMax}
+              required={true}
+              value={this.state.pageOffset}
+              onChange={this.onPageOffsetChange}
             />
 
             <AppSelect
               className="w-full mt-4 sm:ml-3 sm:w-1/2 lg:mt-0"
               id="gene-browser-search"
               label="Display count"
-              value={ this.state.countView }
-              onChange={ this.onDisplayCountSelect }
+              value={this.state.countView}
+              onChange={this.onDisplayCountSelect}
               options={[
                 { value: 5 },
                 { value: 10 },
@@ -194,73 +189,48 @@ export default class GeneBrowser extends Component {
               ]}
             />
           </div>
-
         </div>
 
         <div className="bg-white mt-6">
-          {
-            this.state.geneView.map(({ accession, geneInfo }) => (
-
-              <div
-                className="group flex px-6 py-4 odd:bg-gray-100 hover:bg-yellow-100"
-                key={ accession }
-                onDoubleClick={ () => this.selectGene(accession) }
-              >
-                <div className="w-full">
-                  <div className="font-bold">{ accession }</div>
-                  {
-                    geneInfo.size === 0
-                      ? 'No information available for this gene.'
-                      : (
-                        <div className="flex mt-1 ml-4">
-
-                          <ul className="text-yellow-700">
-                            {
-                              [ ...geneInfo.keys() ].map(key => (
-                                <li key={ key } className="mt-1">{ key }</li>
-                              ))
-                            }
-                          </ul>
-
-                          <ul className="ml-5">
-                            {
-                              [ ...geneInfo.values() ].map((value, index) => (
-                                <li key={ index } className="mt-1">{ value }</li>
-                              ))
-                            }
-                          </ul>
-
-                        </div>
-                      )
-                  }
-                </div>
-
-                <AppButton>
-                  <AppIcon
-                    className="ml-4 w-6 h-6 text-gray-500 invisible group-hover:visible"
-                    file="hero-icons"
-                    id="eye"
-                  />
-                </AppButton>
-
-              </div>
-
-            ))
-          }
+          {this.state.geneView.map(({ accession, geneInfo }) => (
+            <div
+              className="group flex px-6 py-4 odd:bg-gray-100 hover:bg-yellow-100"
+              key={accession}
+              onDoubleClick={() => this.selectGene(accession)}
+            >
+              <GeneCard
+                accession={accession}
+                geneInfo={geneInfo}
+                actions={[
+                  <AppButton
+                    key="gene-details"
+                    onClick={() => this.selectGene(accession)}
+                  >
+                    <AppIcon
+                      className="ml-4 w-6 h-6 text-gray-500 invisible group-hover:visible"
+                      file="hero-icons"
+                      id="eye"
+                    />
+                  </AppButton>,
+                ]}
+              />
+            </div>
+          ))}
         </div>
 
-        {
-          this.state.selectedGene &&
+        {this.state.selectedGene && (
           <AppModal
             className="flex flex-col w-full h-full md:w-5/6 md:h-5/6 lg:w-3/4 2xl:w-1/2"
-            title={ this.state.selectedGene }
-            showModal={ this.state.selectedGene }
-            hideModal={ () => this.selectGene() }
+            title={this.state.selectedGene}
+            showModal={this.state.selectedGene}
+            hideModal={() => this.selectGene()}
           >
-            <GeneDetails geneCounts={ this.state.selectedGeneCounts } />
+            <GeneDetails
+              countUnit={settings.tableSettings.unit}
+              geneCounts={this.state.selectedGeneCounts}
+            />
           </AppModal>
-        }
-
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Description

This PR addresses layout fixes for the gene information (gene-card component) used in figure captions and the gene-browser tool.

## Changes

- Add a new `gene-card` component that can be re-used in captions and the gene-browser.
- Use a flex layout to align each info property with this value or description.
- Fix the plot-caption not having an accession-based key.
- Various color and display changes to the gene-cards displayed in captions.
