### PR TITLE
feat: bars form and formik arrray

### DIFF
--- a/src/components/formik-field/formik-field.tsx
+++ b/src/components/formik-field/formik-field.tsx
@@ -5,6 +5,7 @@ import {
   FormLabel,
   FormErrorMessage,
   Input,
+  InputGroup,
   InputProps,
   VisuallyHidden,
 } from '@chakra-ui/react';
@@ -13,8 +14,10 @@ import { FocusableElement } from '@chakra-ui/utils';
 interface FormikFieldProps extends InputProps {
   name: string;
   label: string;
+  leftChildren?: React.ReactNode;
   hideLabel?: boolean;
   initialFocusRef?: React.MutableRefObject<FocusableElement | null>;
+  rightChildren?: React.ReactNode;
   validate?: FieldValidator;
 }
 
@@ -34,7 +37,6 @@ const FormikField: React.FC<FormikFieldProps> = ({
 
   return (
     <FormControl
-      as="p"
       isInvalid={meta.error !== undefined && meta.touched !== undefined}
       isRequired={props.isRequired}
     >
@@ -45,16 +47,22 @@ const FormikField: React.FC<FormikFieldProps> = ({
       ) : (
         <FormLabel fontWeight="semibold">{label}</FormLabel>
       )}
-      <Input
-        ref={(ref) => (initialFocusRef ? (initialFocusRef.current = ref) : ref)}
-        name={field.name}
-        onBlur={field.onBlur}
-        onChange={field.onChange}
-        multiple={field.multiple}
-        value={field.value}
-        {...props}
-      />
-      {children}
+      <InputGroup>
+        {props.leftChildren}
+        <Input
+          ref={(ref) =>
+            initialFocusRef ? (initialFocusRef.current = ref) : ref
+          }
+          name={field.name}
+          onBlur={field.onBlur}
+          onChange={field.onChange}
+          multiple={field.multiple}
+          value={field.value}
+          {...props}
+        />
+        {children}
+        {props.rightChildren}
+      </InputGroup>
       <FormErrorMessage as="span">{meta.error}</FormErrorMessage>
     </FormControl>
   );

--- a/src/components/formik-field/formik-field.tsx
+++ b/src/components/formik-field/formik-field.tsx
@@ -6,6 +6,7 @@ import {
   FormErrorMessage,
   Input,
   InputGroup,
+  InputGroupProps,
   InputProps,
   VisuallyHidden,
 } from '@chakra-ui/react';
@@ -16,6 +17,7 @@ interface FormikFieldProps extends InputProps {
   label: string;
   leftChildren?: React.ReactNode;
   hideLabel?: boolean;
+  groupProps?: InputGroupProps;
   initialFocusRef?: React.MutableRefObject<FocusableElement | null>;
   rightChildren?: React.ReactNode;
   validate?: FieldValidator;
@@ -23,10 +25,13 @@ interface FormikFieldProps extends InputProps {
 
 const FormikField: React.FC<FormikFieldProps> = ({
   children,
+  groupProps,
   hideLabel,
   initialFocusRef,
   label,
+  leftChildren,
   name,
+  rightChildren,
   validate,
   ...props
 }) => {
@@ -47,8 +52,8 @@ const FormikField: React.FC<FormikFieldProps> = ({
       ) : (
         <FormLabel fontWeight="semibold">{label}</FormLabel>
       )}
-      <InputGroup>
-        {props.leftChildren}
+      <InputGroup {...groupProps}>
+        {leftChildren}
         <Input
           ref={(ref) =>
             initialFocusRef ? (initialFocusRef.current = ref) : ref
@@ -61,7 +66,7 @@ const FormikField: React.FC<FormikFieldProps> = ({
           {...props}
         />
         {children}
-        {props.rightChildren}
+        {rightChildren}
       </InputGroup>
       <FormErrorMessage as="span">{meta.error}</FormErrorMessage>
     </FormControl>

--- a/src/components/formik-field/formik-field.tsx
+++ b/src/components/formik-field/formik-field.tsx
@@ -2,6 +2,7 @@ import { FieldValidator, useField } from 'formik';
 import React from 'react';
 import {
   FormControl,
+  FormControlProps,
   FormLabel,
   FormErrorMessage,
   Input,
@@ -17,6 +18,7 @@ interface FormikFieldProps extends InputProps {
   label: string;
   leftChildren?: React.ReactNode;
   hideLabel?: boolean;
+  controlProps?: FormControlProps;
   groupProps?: InputGroupProps;
   initialFocusRef?: React.MutableRefObject<FocusableElement | null>;
   rightChildren?: React.ReactNode;
@@ -25,6 +27,7 @@ interface FormikFieldProps extends InputProps {
 
 const FormikField: React.FC<FormikFieldProps> = ({
   children,
+  controlProps,
   groupProps,
   hideLabel,
   initialFocusRef,
@@ -42,6 +45,7 @@ const FormikField: React.FC<FormikFieldProps> = ({
 
   return (
     <FormControl
+      {...controlProps}
       isInvalid={meta.error !== undefined && meta.touched !== undefined}
       isRequired={props.isRequired}
     >
@@ -52,7 +56,7 @@ const FormikField: React.FC<FormikFieldProps> = ({
       ) : (
         <FormLabel fontWeight="semibold">{label}</FormLabel>
       )}
-      <InputGroup {...groupProps}>
+      <InputGroup as="span" {...groupProps}>
         {leftChildren}
         <Input
           ref={(ref) =>

--- a/src/components/formik-switch/formik-switch.tsx
+++ b/src/components/formik-switch/formik-switch.tsx
@@ -1,0 +1,81 @@
+import { FieldValidator, useField } from 'formik';
+import React from 'react';
+import {
+  Flex,
+  FormControl,
+  FormControlProps,
+  FormLabel,
+  FormErrorMessage,
+  Switch,
+  SwitchProps,
+  VisuallyHidden,
+} from '@chakra-ui/react';
+import { FocusableElement } from '@chakra-ui/utils';
+
+interface FormikSwitchProps extends SwitchProps {
+  id: string;
+  name: string;
+  label: string;
+  leftChildren?: React.ReactNode;
+  controlProps?: FormControlProps;
+  hideLabel?: boolean;
+  initialFocusRef?: React.MutableRefObject<FocusableElement | null>;
+  rightChildren?: React.ReactNode;
+  validate?: FieldValidator;
+}
+
+const FormikSwitch: React.FC<FormikSwitchProps> = ({
+  // children,
+  controlProps,
+  hideLabel,
+  initialFocusRef,
+  label,
+  name,
+  validate,
+  ...props
+}) => {
+  const [field, meta] = useField({
+    name,
+    validate,
+  });
+
+  return (
+    <FormControl
+      {...controlProps}
+      isInvalid={meta.error !== undefined && meta.touched !== undefined}
+    >
+      <Flex alignItems="flex-end">
+        <Switch
+          colorScheme="orange"
+          ref={(ref) =>
+            initialFocusRef ? (initialFocusRef.current = ref) : ref
+          }
+          isChecked={field.value}
+          name={field.name}
+          onBlur={field.onBlur}
+          onChange={field.onChange}
+          {...props}
+        />
+
+        {hideLabel ? (
+          <VisuallyHidden>
+            <FormLabel htmlFor={props.id}>{label}</FormLabel>
+          </VisuallyHidden>
+        ) : (
+          <FormLabel
+            fontWeight="semibold"
+            color="gray.600"
+            htmlFor={props.id}
+            marginBottom={0}
+            marginLeft="1rem"
+          >
+            {label}
+          </FormLabel>
+        )}
+      </Flex>
+      <FormErrorMessage as="span">{meta.error}</FormErrorMessage>
+    </FormControl>
+  );
+};
+
+export default FormikSwitch;

--- a/src/components/formik-switch/index.tsx
+++ b/src/components/formik-switch/index.tsx
@@ -1,0 +1,3 @@
+import FormikSwitch from './formik-switch';
+
+export default FormikSwitch;

--- a/src/pages/plots/components/bars-form.tsx
+++ b/src/pages/plots/components/bars-form.tsx
@@ -43,10 +43,6 @@ const BarsForm: React.FC<BarsFormProps> = (props) => {
     if (!value) return 'The accession ID cannot be empty';
   };
 
-  const validateLegend: FieldValidator = (value: boolean) => {
-    if (!value) return 'Legend cannot be false';
-  };
-
   return (
     <Formik
       initialValues={{
@@ -73,7 +69,6 @@ const BarsForm: React.FC<BarsFormProps> = (props) => {
                 id="plot-legend"
                 label="Legend"
                 name="withLegend"
-                validate={validateLegend}
               />
 
               <FormikSwitch
@@ -84,7 +79,6 @@ const BarsForm: React.FC<BarsFormProps> = (props) => {
                 id="plot-caption"
                 label="Caption"
                 name="withCaption"
-                validate={validateLegend}
               />
             </Flex>
           </Box>

--- a/src/pages/plots/components/bars-form.tsx
+++ b/src/pages/plots/components/bars-form.tsx
@@ -15,14 +15,16 @@ import {
   Icon,
   IconButton,
   InputRightAddon,
-  Text,
   VisuallyHidden,
 } from '@chakra-ui/react';
 import { FocusableElement } from '@chakra-ui/utils';
+import FormikSwitch from '@/components/formik-switch';
 
 export interface BarsFormAttributes {
-  plotTitle: string;
   accessions: string[];
+  plotTitle: string;
+  withCaption: boolean;
+  withLegend: boolean;
 }
 
 export type BarsFormSubmitHandler = (
@@ -41,121 +43,158 @@ const BarsForm: React.FC<BarsFormProps> = (props) => {
     if (!value) return 'The accession ID cannot be empty';
   };
 
+  const validateLegend: FieldValidator = (value: boolean) => {
+    if (!value) return 'Legend cannot be false';
+  };
+
   return (
     <Formik
-      initialValues={{ plotTitle: '', accessions: [''] }}
+      initialValues={{
+        accessions: [''],
+        plotTitle: '',
+        withCaption: true,
+        withLegend: true,
+      }}
       onSubmit={props.onSubmit}
     >
       {(formProps) => (
-        <Form>
+        <Box as={Form}>
+          <Box as="fieldset">
+            <VisuallyHidden as="legend">
+              Legend and caption switches
+            </VisuallyHidden>
+
+            <Flex as="ul" listStyleType="none">
+              <FormikSwitch
+                controlProps={{
+                  as: 'li',
+                }}
+                color="orange.600"
+                id="plot-legend"
+                label="Legend"
+                name="withLegend"
+                validate={validateLegend}
+              />
+
+              <FormikSwitch
+                controlProps={{
+                  as: 'li',
+                }}
+                color="orange.600"
+                id="plot-caption"
+                label="Caption"
+                name="withCaption"
+                validate={validateLegend}
+              />
+            </Flex>
+          </Box>
+
           <FormikField
+            controlProps={{
+              as: 'p',
+              marginTop: '1rem',
+            }}
+            initialFocusRef={props.initialFocusRef}
             label="Plot Title"
             name="plotTitle"
-            initialFocusRef={props.initialFocusRef}
           />
+
           <FieldArray name="accessions">
             {(helpers) => (
-              <Box as="section">
-                <VisuallyHidden>
-                  <Text as="h1" fontWeight="semibold">
-                    Gene Accessions
-                  </Text>
-                </VisuallyHidden>
+              <Box as="fieldset">
+                <VisuallyHidden as="legend">Gene Accessions</VisuallyHidden>
+
                 {formProps.values.accessions &&
                   formProps.values.accessions.length > 0 &&
                   formProps.values.accessions.map((accession, index) => (
-                    <Flex
-                      alignItems="center"
-                      key={index}
-                      _first={{
+                    <FormikField
+                      controlProps={{
+                        as: 'p',
                         marginTop: '1rem',
                       }}
-                      paddingBottom="1rem"
-                      role="group"
-                    >
-                      <FormikField
-                        groupProps={{
-                          _focusWithin: {
-                            '& > button': {
-                              display: 'inline-flex',
-                            },
+                      groupProps={{
+                        _focusWithin: {
+                          '& > button': {
+                            display: 'inline-flex',
                           },
+                        },
+                      }}
+                      isRequired
+                      key={index}
+                      label={`Gene Accession ${index + 1}`}
+                      name={`accessions.${index}`}
+                      rightChildren={
+                        formProps.values.accessions.length > 1 && (
+                          <InputRightAddon
+                            _focusWithin={{
+                              backgroundColor: 'white',
+                            }}
+                            _hover={{
+                              backgroundColor: 'white',
+                            }}
+                            as="span"
+                            padding={0}
+                          >
+                            <IconButton
+                              _focus={{
+                                color: 'red.600',
+                                outline: 'none',
+                              }}
+                              _groupHover={{
+                                color: 'red.600',
+                              }}
+                              aria-label={`Remove ${accession}`}
+                              color="gray.600"
+                              display="flex"
+                              justifyContent="center"
+                              icon={<FaTrash />}
+                              onClick={() => helpers.remove(index)}
+                              size="md"
+                              variant="unstyled"
+                            />
+                          </InputRightAddon>
+                        )
+                      }
+                      validate={validateAccession}
+                    >
+                      {/* INSERT BUTTON */}
+                      <Box
+                        display="none"
+                        color="gray.500"
+                        _groupFocus={{
+                          display: 'inline-flex',
                         }}
-                        isRequired
-                        label={`Gene Accession ${index + 1}`}
-                        name={`accessions.${index}`}
-                        rightChildren={
-                          formProps.values.accessions.length > 1 && (
-                            <InputRightAddon
-                              _focusWithin={{
-                                backgroundColor: 'white',
-                              }}
-                              _hover={{
-                                backgroundColor: 'white',
-                              }}
-                              padding={0}
-                            >
-                              <IconButton
-                                _focus={{
-                                  color: 'red.600',
-                                  outline: 'none',
-                                }}
-                                _groupHover={{
-                                  color: 'red.600',
-                                }}
-                                aria-label={`Remove ${accession}`}
-                                color="gray.600"
-                                display="flex"
-                                justifyContent="center"
-                                icon={<FaTrash />}
-                                onClick={() => helpers.remove(index)}
-                                size="md"
-                                variant="unstyled"
-                              />
-                            </InputRightAddon>
-                          )
-                        }
-                        validate={validateAccession}
+                        _groupHover={{
+                          display: 'inline-flex',
+                        }}
+                        _focus={{
+                          backgroundColor: 'orange.600',
+                          color: 'white',
+                          outline: 'none',
+                        }}
+                        _hover={{
+                          backgroundColor: 'orange.600',
+                          color: 'white',
+                        }}
+                        alignItems="center"
+                        as="button"
+                        aria-label={`Insert new below`}
+                        backgroundColor="white"
+                        height="1rem"
+                        justifyContent="center"
+                        left="43%"
+                        padding=".75rem"
+                        position="absolute"
+                        rounded="full"
+                        top="28px"
+                        type="button"
+                        width="1rem"
+                        zIndex="popover"
+                        onClick={() => helpers.insert(index + 1, '')}
                       >
-                        {/* INSERT BUTTON */}
-                        <Box
-                          display="none"
-                          color="gray.500"
-                          _groupFocus={{
-                            display: 'inline-flex',
-                          }}
-                          _groupHover={{
-                            display: 'inline-flex',
-                          }}
-                          _focus={{
-                            backgroundColor: 'orange.600',
-                            color: 'white',
-                            outline: 'none',
-                          }}
-                          _hover={{
-                            backgroundColor: 'orange.600',
-                            color: 'white',
-                          }}
-                          alignItems="center"
-                          as="button"
-                          aria-label={`Insert new below`}
-                          backgroundColor="white"
-                          height="1rem"
-                          justifyContent="center"
-                          left="43%"
-                          padding=".75rem"
-                          position="absolute"
-                          rounded="full"
-                          top="28px"
-                          type="button"
-                          width="1rem"
-                          zIndex="popover"
-                          onClick={() => helpers.insert(index + 1, '')}
-                        >
-                          <Icon as={FaPlus} />
-                        </Box>
-                      </FormikField>
-                    </Flex>
+                        <Icon as={FaPlus} />
+                      </Box>
+                    </FormikField>
                   ))}
 
                 <Button
@@ -167,9 +206,10 @@ const BarsForm: React.FC<BarsFormProps> = (props) => {
                     backgroundColor: 'orange.100',
                   }}
                   colorScheme="orange"
+                  marginTop="1rem"
                   type="button"
-                  variant="ghost"
                   onClick={() => helpers.push('')}
+                  variant="ghost"
                 >
                   Add New
                 </Button>
@@ -192,7 +232,7 @@ const BarsForm: React.FC<BarsFormProps> = (props) => {
               Load
             </Button>
           </Flex>
-        </Form>
+        </Box>
       )}
     </Formik>
   );

--- a/src/pages/plots/components/bars-form.tsx
+++ b/src/pages/plots/components/bars-form.tsx
@@ -1,0 +1,201 @@
+import {
+  Formik,
+  Form,
+  FieldArray,
+  FieldValidator,
+  FormikHelpers,
+} from 'formik';
+import React from 'react';
+import { FaPlus, FaTrash } from 'react-icons/fa';
+import FormikField from '@/components/formik-field';
+import {
+  Box,
+  Button,
+  Flex,
+  Icon,
+  IconButton,
+  InputRightAddon,
+  Text,
+  VisuallyHidden,
+} from '@chakra-ui/react';
+import { FocusableElement } from '@chakra-ui/utils';
+
+export interface BarsFormAttributes {
+  plotTitle: string;
+  accessions: string[];
+}
+
+export type BarsFormSubmitHandler = (
+  values: BarsFormAttributes,
+  actions: FormikHelpers<BarsFormAttributes>
+) => void;
+
+export interface BarsFormProps {
+  initialFocusRef?: React.MutableRefObject<FocusableElement | null>;
+  onCancel?: () => void;
+  onSubmit: BarsFormSubmitHandler;
+}
+
+const BarsForm: React.FC<BarsFormProps> = (props) => {
+  const validateAccession: FieldValidator = (value: string) => {
+    if (!value) return 'The accession ID cannot be empty';
+  };
+
+  return (
+    <Formik
+      initialValues={{ plotTitle: '', accessions: [''] }}
+      onSubmit={props.onSubmit}
+    >
+      {(formProps) => (
+        <Form>
+          <FormikField
+            label="Plot Title"
+            name="plotTitle"
+            initialFocusRef={props.initialFocusRef}
+          />
+          <FieldArray name="accessions">
+            {(helpers) => (
+              <Box as="section">
+                <VisuallyHidden>
+                  <Text as="h1" fontWeight="semibold">
+                    Gene Accessions
+                  </Text>
+                </VisuallyHidden>
+                {formProps.values.accessions &&
+                  formProps.values.accessions.length > 0 &&
+                  formProps.values.accessions.map((accession, index) => (
+                    <Flex
+                      alignItems="center"
+                      key={index}
+                      _first={{
+                        marginTop: '1rem',
+                      }}
+                      paddingBottom="1rem"
+                      role="group"
+                    >
+                      <FormikField
+                        groupProps={{
+                          _focusWithin: {
+                            '& > button': {
+                              display: 'inline-flex',
+                            },
+                          },
+                        }}
+                        isRequired
+                        label={`Gene Accession ${index + 1}`}
+                        name={`accessions.${index}`}
+                        rightChildren={
+                          formProps.values.accessions.length > 1 && (
+                            <InputRightAddon
+                              _focusWithin={{
+                                backgroundColor: 'white',
+                              }}
+                              _hover={{
+                                backgroundColor: 'white',
+                              }}
+                              padding={0}
+                            >
+                              <IconButton
+                                _focus={{
+                                  color: 'red.600',
+                                  outline: 'none',
+                                }}
+                                _groupHover={{
+                                  color: 'red.600',
+                                }}
+                                aria-label={`Remove ${accession}`}
+                                color="gray.600"
+                                display="flex"
+                                justifyContent="center"
+                                icon={<FaTrash />}
+                                onClick={() => helpers.remove(index)}
+                                size="md"
+                                variant="unstyled"
+                              />
+                            </InputRightAddon>
+                          )
+                        }
+                        validate={validateAccession}
+                      >
+                        {/* INSERT BUTTON */}
+                        <Box
+                          display="none"
+                          color="gray.500"
+                          _groupFocus={{
+                            display: 'inline-flex',
+                          }}
+                          _groupHover={{
+                            display: 'inline-flex',
+                          }}
+                          _focus={{
+                            backgroundColor: 'orange.600',
+                            color: 'white',
+                            outline: 'none',
+                          }}
+                          _hover={{
+                            backgroundColor: 'orange.600',
+                            color: 'white',
+                          }}
+                          alignItems="center"
+                          as="button"
+                          aria-label={`Insert new below`}
+                          backgroundColor="white"
+                          height="1rem"
+                          justifyContent="center"
+                          left="43%"
+                          padding=".75rem"
+                          position="absolute"
+                          rounded="full"
+                          top="28px"
+                          type="button"
+                          width="1rem"
+                          zIndex="popover"
+                          onClick={() => helpers.insert(index + 1, '')}
+                        >
+                          <Icon as={FaPlus} />
+                        </Box>
+                      </FormikField>
+                    </Flex>
+                  ))}
+
+                <Button
+                  _focus={{
+                    outline: 'none',
+                    backgroundColor: 'orange.100',
+                  }}
+                  _hover={{
+                    backgroundColor: 'orange.100',
+                  }}
+                  colorScheme="orange"
+                  type="button"
+                  variant="ghost"
+                  onClick={() => helpers.push('')}
+                >
+                  Add New
+                </Button>
+              </Box>
+            )}
+          </FieldArray>
+
+          <Flex as="p" paddingY={6} justifyContent="flex-end">
+            <Button onClick={props.onCancel} colorScheme="red" variant="ghost">
+              Cancel
+            </Button>
+
+            <Button
+              colorScheme="orange"
+              isLoading={formProps.isSubmitting}
+              marginLeft=".5rem"
+              type="submit"
+              variant="solid"
+            >
+              Load
+            </Button>
+          </Flex>
+        </Form>
+      )}
+    </Formik>
+  );
+};
+
+export default BarsForm;

--- a/src/pages/plots/plots-home.tsx
+++ b/src/pages/plots/plots-home.tsx
@@ -105,7 +105,9 @@ const PlotsHome: React.FC = () => {
         initialFocusRef={refBarsFormInitialFocus}
         isOpen={isBarsFormOpen}
         onClose={onBarsFormClose}
+        size="xl"
         title="Bars Plot"
+        scrollBehavior="outside"
       >
         <BarsForm
           initialFocusRef={refBarsFormInitialFocus}

--- a/src/pages/plots/plots-home.tsx
+++ b/src/pages/plots/plots-home.tsx
@@ -49,7 +49,7 @@ const PlotsHome: React.FC = () => {
     <Flex as="main" flexGrow={1}>
       <Sidebar top={0} maxWidth="17rem" minWidth="6.5rem">
         <SidebarButton
-          text="Bar Plot"
+          text="Bars Plot"
           icon={TextIcon('BAR')}
           alignItems="baseline"
           onClick={onBarsFormOpen}

--- a/src/pages/plots/plots-home.tsx
+++ b/src/pages/plots/plots-home.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import { observer } from 'mobx-react';
 
-import PlotlyPlot from './components/PlotlyPlot';
-import PlotCaption from './components/PlotCaption';
-
 import { plotStore } from '@/store/plot-store';
 import { infoTable } from '@/store/data-store';
 import { colors } from '@/utils/plotsHelper';
 
 import Sidebar, { SidebarButton } from '@/components/nav-sidebar';
-import { Flex, Text } from '@chakra-ui/react';
+import FormikModal from '@/components/formik-modal';
+import { Flex, Text, useDisclosure } from '@chakra-ui/react';
+import { FocusableElement } from '@chakra-ui/utils';
+
+import PlotlyPlot from './components/PlotlyPlot';
+import PlotCaption from './components/PlotCaption';
+import BarsForm, { BarsFormSubmitHandler } from './components/bars-form';
 
 const TextIcon = (text: string) =>
   function IconRenderer(): JSX.Element {
@@ -28,6 +31,20 @@ const TextIcon = (text: string) =>
   };
 
 const PlotsHome: React.FC = () => {
+  /* BARS PLOT */
+  const refBarsFormInitialFocus = React.useRef<FocusableElement | null>(null);
+
+  const {
+    isOpen: isBarsFormOpen,
+    onOpen: onBarsFormOpen,
+    onClose: onBarsFormClose,
+  } = useDisclosure();
+
+  const onBarsFormSubmit: BarsFormSubmitHandler = (values, actions) => {
+    console.log({ values });
+    actions.setSubmitting(false);
+  };
+
   return (
     <Flex as="main" flexGrow={1}>
       <Sidebar top={0} maxWidth="17rem" minWidth="6.5rem">
@@ -35,6 +52,7 @@ const PlotsHome: React.FC = () => {
           text="Bar Plot"
           icon={TextIcon('BAR')}
           alignItems="baseline"
+          onClick={onBarsFormOpen}
         />
 
         <SidebarButton
@@ -82,6 +100,19 @@ const PlotsHome: React.FC = () => {
           </PlotlyPlot>
         ))}
       </Flex>
+
+      <FormikModal
+        initialFocusRef={refBarsFormInitialFocus}
+        isOpen={isBarsFormOpen}
+        onClose={onBarsFormClose}
+        title="Bars Plot"
+      >
+        <BarsForm
+          initialFocusRef={refBarsFormInitialFocus}
+          onCancel={onBarsFormClose}
+          onSubmit={onBarsFormSubmit}
+        />
+      </FormikModal>
     </Flex>
   );
 };


### PR DESCRIPTION
## Summary

This PR adds functionality to the **Bars Plot** sidebar menu in `plots-home` to open a new `bars-form` component implementing a subset of the old **New Plot** menu. The new form implements a formik array field to input accessions.

## Changes
- Add support for left and right addon and element children in `formik-field`.
- Add a new `formik-switch` component that integrates `formik` with `chakra-ui`'s `switch` component.
- Add a new `bars-form` component with all necessary inputs to create a bars plot. In this component, accession inputs are implemented using `formik`'s `ArrayField`.
- Add functionality to the **Bars Plot** sidebar menu so that now it opens the `bars-form` within a modal.