### PR TITLE
refactor: use plot-container for plotly plots

### DIFF
--- a/src/css/plotly.css
+++ b/src/css/plotly.css
@@ -1,6 +1,7 @@
 .js-plotly-plot .plotly .modebar {
-  @apply flex justify-center;
-  @apply w-full;
+  display: flex;
+  justify-content: center;
+  width: 100%
 }
 
 /* .js-plotly-plot .plotly .modebar--hover > :not(.watermark) {
@@ -8,5 +9,5 @@
 } */
 
 .js-plotly-plot .plotly .modebar-group {
-  @apply flex;
+  display: flex;
 }

--- a/src/pages/plots/components/PlotlyPlot.tsx
+++ b/src/pages/plots/components/PlotlyPlot.tsx
@@ -96,6 +96,7 @@ const PlotlyPlot: React.FC<GxpPlotly> = (props) => {
         status="idle"
         figureRef={figureRef}
         title={props.options.plotTitle}
+        direction="column"
       >
         <Plot
           ref={(ref) => (plotRef.current = ref)}

--- a/src/pages/plots/components/PlotlyPlot.tsx
+++ b/src/pages/plots/components/PlotlyPlot.tsx
@@ -39,6 +39,13 @@ const PlotlyPlot: React.FC<GxpPlotly> = (props) => {
   const timeoutRef = React.useRef<number>();
 
   const [layout, setLayout] = React.useState<Partial<Layout>>({
+    title: {
+      text: props.options.plotTitle,
+      font: {
+        size: 20,
+      },
+      y: 0.9,
+    },
     showlegend: props.options.showlegend,
     legend: {
       orientation: 'h',
@@ -91,12 +98,7 @@ const PlotlyPlot: React.FC<GxpPlotly> = (props) => {
 
   return (
     <PlotContext.Provider value={{ hoveredGene: name }}>
-      <PlotContainer
-        status="idle"
-        figureRef={figureRef}
-        title={props.options.plotTitle}
-        direction="column"
-      >
+      <PlotContainer status="idle" figureRef={figureRef}>
         <Plot
           ref={(ref) => (plotRef.current = ref)}
           data={props.data}
@@ -104,7 +106,7 @@ const PlotlyPlot: React.FC<GxpPlotly> = (props) => {
           onHover={onPlotHover}
           onUnhover={onPlotUnhover}
         />
-        <Box marginX="12" width="full">
+        <Box marginX="12" width="full" overflow="auto">
           {props.children}
         </Box>
       </PlotContainer>

--- a/src/pages/plots/components/PlotlyPlot.tsx
+++ b/src/pages/plots/components/PlotlyPlot.tsx
@@ -68,8 +68,8 @@ const PlotlyPlot: React.FC<GxpPlotly> = (props) => {
       timeoutRef.current = id;
     });
 
-    if (figureRef.current) {
-      resizeObserver.observe(figureRef.current);
+    if (internalRef) {
+      resizeObserver.observe(internalRef);
     }
 
     return () => {

--- a/src/pages/plots/components/PlotlyPlot.tsx
+++ b/src/pages/plots/components/PlotlyPlot.tsx
@@ -55,7 +55,7 @@ const PlotlyPlot: React.FC<GxpPlotly> = (props) => {
   });
   React.useEffect(function resizePlot() {
     let id: number;
-    let figureRefValue: HTMLDivElement | null = null;
+    const internalRef = figureRef.current;
     const resizeObserver = new ResizeObserver((entries) => {
       clearTimeout(timeoutRef.current);
       id = window.setTimeout(() => {
@@ -70,11 +70,10 @@ const PlotlyPlot: React.FC<GxpPlotly> = (props) => {
 
     if (figureRef.current) {
       resizeObserver.observe(figureRef.current);
-      figureRefValue = figureRef.current;
     }
 
     return () => {
-      if (figureRefValue) resizeObserver.unobserve(figureRefValue);
+      if (internalRef) resizeObserver.unobserve(internalRef);
       if (id) clearTimeout(id);
     };
   }, []);

--- a/src/pages/plots/components/PlotlyPlot.tsx
+++ b/src/pages/plots/components/PlotlyPlot.tsx
@@ -1,4 +1,3 @@
-import { Flex } from '@chakra-ui/layout';
 import { Layout, PlotMouseEvent } from 'plotly.js';
 import React, { createContext } from 'react';
 import Plot from 'react-plotly.js';
@@ -6,6 +5,8 @@ import { PlotData } from 'plotly.js';
 import { settings } from '@/store/settings';
 import { observer } from 'mobx-react';
 import { GxpPlotly, PlotlyOptions } from '@/types/plots';
+import PlotContainer from './plot-container';
+import { Box } from '@chakra-ui/react';
 
 export const colors = [
   '#c7566f',
@@ -38,14 +39,6 @@ const PlotlyPlot: React.FC<GxpPlotly> = (props) => {
   const timeoutRef = React.useRef<number>();
 
   const [layout, setLayout] = React.useState<Partial<Layout>>({
-    title: {
-      text: props.options.plotTitle,
-      font: {
-        family: 'ABeeZee',
-        size: 24,
-      },
-      y: 0.9,
-    },
     showlegend: props.options.showlegend,
     legend: {
       orientation: 'h',
@@ -58,14 +51,11 @@ const PlotlyPlot: React.FC<GxpPlotly> = (props) => {
       },
       hoverformat: '.2f',
     },
-    // xaxis: {
-    //   tickangle: ,
-    // },
     colorway: colors,
   });
   React.useEffect(function resizePlot() {
     let id: number;
-
+    let figureRefValue: HTMLDivElement | null = null;
     const resizeObserver = new ResizeObserver((entries) => {
       clearTimeout(timeoutRef.current);
       id = window.setTimeout(() => {
@@ -80,10 +70,11 @@ const PlotlyPlot: React.FC<GxpPlotly> = (props) => {
 
     if (figureRef.current) {
       resizeObserver.observe(figureRef.current);
+      figureRefValue = figureRef.current;
     }
 
     return () => {
-      if (figureRef.current) resizeObserver.unobserve(figureRef.current);
+      if (figureRefValue) resizeObserver.unobserve(figureRefValue);
       if (id) clearTimeout(id);
     };
   }, []);
@@ -101,18 +92,10 @@ const PlotlyPlot: React.FC<GxpPlotly> = (props) => {
 
   return (
     <PlotContext.Provider value={{ hoveredGene: name }}>
-      <Flex
-        as="figure"
-        ref={(ref) => (figureRef.current = ref)}
-        position="relative"
-        direction="column"
-        boxShadow="lg"
-        bg="white"
-        overflow="auto"
-        resize="horizontal"
-        width="full"
-        m="3"
-        py="6"
+      <PlotContainer
+        status="idle"
+        figureRef={figureRef}
+        title={props.options.plotTitle}
       >
         <Plot
           ref={(ref) => (plotRef.current = ref)}
@@ -121,8 +104,10 @@ const PlotlyPlot: React.FC<GxpPlotly> = (props) => {
           onHover={onPlotHover}
           onUnhover={onPlotUnhover}
         />
-        <div className="mx-12">{props.children}</div>
-      </Flex>
+        <Box marginX="12" width="full">
+          {props.children}
+        </Box>
+      </PlotContainer>
     </PlotContext.Provider>
   );
 };

--- a/src/pages/plots/components/heatmap-plot.tsx
+++ b/src/pages/plots/components/heatmap-plot.tsx
@@ -70,13 +70,20 @@ const HeatmapPlot: React.FC<HeatmapPlotProps> = (props) => {
         timeoutId = window.setTimeout(() => {
           const figureStyle = window.getComputedStyle(entries[0].target, null);
 
-          const clientPadding =
-            parseFloat(figureStyle.getPropertyValue('padding')) * 2;
-
-          // const clientWidth =
-          //   parseFloat(figureStyle.getPropertyValue('width')) - clientPadding;
-          // const clientHeight =
-          //   parseFloat(figureStyle.getPropertyValue('height')) - clientPadding;
+          const clientPaddingTop = parseFloat(
+            figureStyle.getPropertyValue('padding-top')
+          );
+          const clientPaddingBottom = parseFloat(
+            figureStyle.getPropertyValue('padding-bottom')
+          );
+          const clientPaddingLeft = parseFloat(
+            figureStyle.getPropertyValue('padding-left')
+          );
+          const clientPaddingRight = parseFloat(
+            figureStyle.getPropertyValue('padding-right')
+          );
+          const clientPaddingX = clientPaddingRight + clientPaddingLeft;
+          const clientPaddingY = clientPaddingTop + clientPaddingBottom;
 
           const ticksHeight = props.binData
             .map((data) =>
@@ -94,10 +101,10 @@ const HeatmapPlot: React.FC<HeatmapPlotProps> = (props) => {
                 : Math.max(previous, current)
             );
 
-          const clientWidth = entries[0].target.clientWidth - clientPadding;
+          const clientWidth = entries[0].target.clientWidth - clientPaddingX;
           const clientHeight =
             entries[0].target.clientHeight -
-            clientPadding -
+            clientPaddingY -
             (ticksHeight ?? 0) -
             50;
 

--- a/src/pages/plots/components/heatmap-plot.tsx
+++ b/src/pages/plots/components/heatmap-plot.tsx
@@ -85,7 +85,7 @@ const HeatmapPlot: React.FC<HeatmapPlotProps> = (props) => {
           const clientPaddingX = clientPaddingRight + clientPaddingLeft;
           const clientPaddingY = clientPaddingTop + clientPaddingBottom;
 
-          const ticksHeight = props.binData
+          const tickLabelHeight = props.binData
             .map((data) =>
               getStringWidth(data.bin, {
                 'font-size': 14,
@@ -105,8 +105,8 @@ const HeatmapPlot: React.FC<HeatmapPlotProps> = (props) => {
           const clientHeight =
             entries[0].target.clientHeight -
             clientPaddingY -
-            (ticksHeight ?? 0) -
-            50;
+            (tickLabelHeight ?? 0) -
+            10; // Tick line height
 
           const dataLen = props.binData.length;
           const binWidth = clientWidth / dataLen;

--- a/src/pages/plots/components/plot-container.tsx
+++ b/src/pages/plots/components/plot-container.tsx
@@ -4,11 +4,13 @@ import { Flex, FlexProps, Spinner } from '@chakra-ui/react';
 interface PlotContainerProps extends FlexProps {
   status: 'idle' | 'loading';
   figureRef?: React.MutableRefObject<HTMLDivElement | null>;
+  title?: string;
 }
 
 const PlotContainer: React.FC<PlotContainerProps> = ({
   status,
   figureRef,
+  title,
   ...props
 }) => {
   return (
@@ -16,7 +18,8 @@ const PlotContainer: React.FC<PlotContainerProps> = ({
       as="figure"
       alignItems="center"
       backgroundColor="white"
-      height={900}
+      boxShadow="lg"
+      direction="column"
       justifyContent="center"
       margin={3}
       overflow="hidden"
@@ -29,9 +32,10 @@ const PlotContainer: React.FC<PlotContainerProps> = ({
           background: 'gray.400',
         },
       }}
-      width="100%"
+      width="full"
       {...props}
     >
+      {title && <h1>{title}</h1>}
       {status === 'idle' ? (
         props.children
       ) : (

--- a/src/pages/plots/components/plot-container.tsx
+++ b/src/pages/plots/components/plot-container.tsx
@@ -21,7 +21,7 @@ const PlotContainer: React.FC<PlotContainerProps> = ({
       justifyContent="center"
       margin={3}
       overflow="hidden"
-      height={900}
+      height={800}
       padding={6}
       ref={(ref) => (figureRef ? (figureRef.current = ref) : ref)}
       resize="horizontal"

--- a/src/pages/plots/components/plot-container.tsx
+++ b/src/pages/plots/components/plot-container.tsx
@@ -4,13 +4,11 @@ import { Flex, FlexProps, Spinner } from '@chakra-ui/react';
 interface PlotContainerProps extends FlexProps {
   status: 'idle' | 'loading';
   figureRef?: React.MutableRefObject<HTMLDivElement | null>;
-  title?: string;
 }
 
 const PlotContainer: React.FC<PlotContainerProps> = ({
   status,
   figureRef,
-  title,
   ...props
 }) => {
   return (
@@ -18,10 +16,12 @@ const PlotContainer: React.FC<PlotContainerProps> = ({
       as="figure"
       alignItems="center"
       backgroundColor="white"
-      boxShadow="lg"
+      boxShadow="sm"
+      flexDirection="column"
       justifyContent="center"
       margin={3}
       overflow="hidden"
+      height={900}
       padding={6}
       ref={(ref) => (figureRef ? (figureRef.current = ref) : ref)}
       resize="horizontal"
@@ -34,7 +34,6 @@ const PlotContainer: React.FC<PlotContainerProps> = ({
       width="100%"
       {...props}
     >
-      {title && <h1>{title}</h1>}
       {status === 'idle' ? (
         props.children
       ) : (

--- a/src/pages/plots/components/plot-container.tsx
+++ b/src/pages/plots/components/plot-container.tsx
@@ -19,7 +19,6 @@ const PlotContainer: React.FC<PlotContainerProps> = ({
       alignItems="center"
       backgroundColor="white"
       boxShadow="lg"
-      direction="column"
       justifyContent="center"
       margin={3}
       overflow="hidden"
@@ -32,7 +31,7 @@ const PlotContainer: React.FC<PlotContainerProps> = ({
           background: 'gray.400',
         },
       }}
-      width="full"
+      width="100%"
       {...props}
     >
       {title && <h1>{title}</h1>}

--- a/src/pages/plots/plots-home.tsx
+++ b/src/pages/plots/plots-home.tsx
@@ -190,6 +190,7 @@ const PlotsHome: React.FC = () => {
         role="region"
         width="100%"
         margin={2}
+        overflow="hidden"
       >
         {plotStore.plots.map((plot) => {
           if (plot.isLoading) {


### PR DESCRIPTION
## Summary
This PR implements the plot-container for PlotlyPlot component as well as moving the title to the plot-container instead of using plotly to set the title.

## Changes

- refactor: use plot-container for plotly plots
- refactor: plot-container to display plot-title as h1
- fix: warning to cleanup ref in resizePlot useEffect
- fix: heatmap padding not a property value in firefox