### PR TITLE
feat: accession autocomplete

### DIFF
--- a/src/components/formik-accession/formik-accession.tsx
+++ b/src/components/formik-accession/formik-accession.tsx
@@ -1,0 +1,94 @@
+import { FieldValidator, useField } from 'formik';
+import React from 'react';
+import {
+  Box,
+  FormControl,
+  FormControlProps,
+  FormLabel,
+  FormErrorMessage,
+  Input,
+  InputGroup,
+  InputGroupProps,
+  InputProps,
+  VisuallyHidden,
+} from '@chakra-ui/react';
+import { FocusableElement } from '@chakra-ui/utils';
+import { useMatchAccession } from '@/hooks';
+
+interface FormikAccessionProps extends InputProps {
+  name: string;
+  label: string;
+  leftChildren?: React.ReactNode;
+  hideLabel?: boolean;
+  controlProps?: FormControlProps;
+  groupProps?: InputGroupProps;
+  initialFocusRef?: React.MutableRefObject<FocusableElement | null>;
+  rightChildren?: React.ReactNode;
+  validate?: FieldValidator;
+}
+
+const FormikAccession: React.FC<FormikAccessionProps> = ({
+  children,
+  controlProps,
+  groupProps,
+  hideLabel,
+  initialFocusRef,
+  label,
+  leftChildren,
+  name,
+  rightChildren,
+  validate,
+  ...props
+}) => {
+  const [field, meta] = useField({
+    name,
+    validate,
+  });
+
+  const matches = useMatchAccession({
+    accession: field.value,
+  });
+
+  return (
+    <FormControl
+      {...controlProps}
+      isInvalid={meta.error !== undefined && meta.touched !== undefined}
+      isRequired={props.isRequired}
+    >
+      {hideLabel ? (
+        <VisuallyHidden>
+          <FormLabel fontWeight="semibold">{label}</FormLabel>
+        </VisuallyHidden>
+      ) : (
+        <FormLabel fontWeight="semibold">{label}</FormLabel>
+      )}
+      <InputGroup as="span" {...groupProps}>
+        {leftChildren}
+        <Input
+          ref={(ref) =>
+            initialFocusRef ? (initialFocusRef.current = ref) : ref
+          }
+          name={field.name}
+          onBlur={field.onBlur}
+          onChange={field.onChange}
+          multiple={field.multiple}
+          value={field.value}
+          {...props}
+          list={`${field.name}-list`}
+        />
+
+        <Box as="datalist" id={`${field.name}-list`}>
+          {matches.map((match) => (
+            <Box as="option" key={match} value={match} />
+          ))}
+        </Box>
+
+        {children}
+        {rightChildren}
+      </InputGroup>
+      <FormErrorMessage as="span">{meta.error}</FormErrorMessage>
+    </FormControl>
+  );
+};
+
+export default FormikAccession;

--- a/src/components/formik-accession/index.tsx
+++ b/src/components/formik-accession/index.tsx
@@ -1,0 +1,3 @@
+import FormikAccession from './formik-accession';
+
+export default FormikAccession;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,3 @@
+import useMatchAccession from './match-accesion';
+
+export { useMatchAccession };

--- a/src/hooks/match-accesion.ts
+++ b/src/hooks/match-accesion.ts
@@ -1,0 +1,40 @@
+import React from 'react';
+import { dataTable } from '@/store/data-store';
+import { RequireExactlyOne } from 'type-fest';
+
+interface UseMatchAccessionOptions {
+  accession?: string;
+  maxSize?: number;
+}
+
+type MatchAccession = (accession: string) => string[];
+
+function useMatchAccession(): MatchAccession;
+function useMatchAccession(
+  options: RequireExactlyOne<UseMatchAccessionOptions, 'accession'>
+): string[];
+function useMatchAccession(
+  options?: UseMatchAccessionOptions
+): string[] | MatchAccession {
+  const matchToStoreAccessions = React.useCallback((accession: string) => {
+    const rowNamesSnapshot = dataTable.rowNames;
+    const maxSize = 10;
+
+    // Update the search window with the accession matching ids
+    const accessionIdsView: string[] = [];
+
+    for (let i = 0; i < rowNamesSnapshot.length; i++) {
+      if (rowNamesSnapshot[i].includes(accession))
+        accessionIdsView.push(rowNamesSnapshot[i]);
+      if (accessionIdsView.length >= maxSize) break;
+    }
+
+    return accessionIdsView;
+  }, []);
+
+  return options?.accession !== undefined
+    ? matchToStoreAccessions(options.accession)
+    : matchToStoreAccessions;
+}
+
+export default useMatchAccession;

--- a/src/pages/plots/components/bars-form.tsx
+++ b/src/pages/plots/components/bars-form.tsx
@@ -7,6 +7,7 @@ import {
 } from 'formik';
 import React from 'react';
 import { FaPlus, FaTrash } from 'react-icons/fa';
+import { FocusableElement } from '@chakra-ui/utils';
 import FormikField from '@/components/formik-field';
 import {
   Box,
@@ -17,8 +18,8 @@ import {
   InputRightAddon,
   VisuallyHidden,
 } from '@chakra-ui/react';
-import { FocusableElement } from '@chakra-ui/utils';
 import FormikSwitch from '@/components/formik-switch';
+import FormikAccession from '@/components/formik-accession';
 
 export interface BarsFormAttributes {
   accessions: string[];
@@ -101,7 +102,7 @@ const BarsForm: React.FC<BarsFormProps> = (props) => {
                 {formProps.values.accessions &&
                   formProps.values.accessions.length > 0 &&
                   formProps.values.accessions.map((accession, index) => (
-                    <FormikField
+                    <FormikAccession
                       controlProps={{
                         as: 'p',
                         marginTop: '1rem',
@@ -188,7 +189,7 @@ const BarsForm: React.FC<BarsFormProps> = (props) => {
                       >
                         <Icon as={FaPlus} />
                       </Box>
-                    </FormikField>
+                    </FormikAccession>
                   ))}
 
                 <Button

--- a/src/pages/plots/components/individual-lines-form.tsx
+++ b/src/pages/plots/components/individual-lines-form.tsx
@@ -7,6 +7,7 @@ import {
 } from 'formik';
 import React from 'react';
 import { FaPlus, FaTrash } from 'react-icons/fa';
+import FormikAccession from '@/components/formik-accession';
 import FormikField from '@/components/formik-field';
 import {
   Box,
@@ -101,7 +102,7 @@ const IndividualLinesForm: React.FC<IndividualLinesFormProps> = (props) => {
                 {formProps.values.accessions &&
                   formProps.values.accessions.length > 0 &&
                   formProps.values.accessions.map((accession, index) => (
-                    <FormikField
+                    <FormikAccession
                       controlProps={{
                         as: 'p',
                         marginTop: '1rem',
@@ -188,7 +189,7 @@ const IndividualLinesForm: React.FC<IndividualLinesFormProps> = (props) => {
                       >
                         <Icon as={FaPlus} />
                       </Box>
-                    </FormikField>
+                    </FormikAccession>
                   ))}
 
                 <Button

--- a/src/pages/plots/components/stacked-lines-form.tsx
+++ b/src/pages/plots/components/stacked-lines-form.tsx
@@ -7,6 +7,7 @@ import {
 } from 'formik';
 import React from 'react';
 import { FaPlus, FaTrash } from 'react-icons/fa';
+import FormikAccession from '@/components/formik-accession';
 import FormikField from '@/components/formik-field';
 import {
   Box,
@@ -101,7 +102,7 @@ const StackedLinesForm: React.FC<StackedLinesFormProps> = (props) => {
                 {formProps.values.accessions &&
                   formProps.values.accessions.length > 0 &&
                   formProps.values.accessions.map((accession, index) => (
-                    <FormikField
+                    <FormikAccession
                       controlProps={{
                         as: 'p',
                         marginTop: '1rem',
@@ -188,7 +189,7 @@ const StackedLinesForm: React.FC<StackedLinesFormProps> = (props) => {
                       >
                         <Icon as={FaPlus} />
                       </Box>
-                    </FormikField>
+                    </FormikAccession>
                   ))}
 
                 <Button


### PR DESCRIPTION
## Summary

This PR adds autocompletion to accession inputs in bars and line plots.

## Changes
- Add new `useMatchAccession` hook.
- Add new `formik-accession` input component`.
- Replace `formik-field` with `formik-accession` in bars and lines plots.

## Notes
- Ignore the left axis to heatmap re-commit. It's been a long day and I don't want to deal with that... 