### PR TITLE
feat: app layout and flow tweaks

### DIFF
--- a/src/app-home.tsx
+++ b/src/app-home.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { Redirect } from 'react-router-dom';
+
+const AppHome: React.FC = () => {
+  return <Redirect to="/data" />;
+};
+
+export default AppHome;

--- a/src/app-routes.tsx
+++ b/src/app-routes.tsx
@@ -8,6 +8,7 @@ import ToolsRoutes from './pages/tools/tools-routes';
 const AppRoutes: React.FC = () => {
   return (
     <Switch>
+      <Route exact path="/" component={DataRoutes} />
       <Route path="/data" component={DataRoutes} />
       <Route path="/plots" component={PlotsRoutes} />
       <Route path="/tools" component={ToolsRoutes} />

--- a/src/app-routes.tsx
+++ b/src/app-routes.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 
+import AppHome from './app-home';
 import DataRoutes from './pages/data/data-routes';
 import PlotsRoutes from './pages/plots/plots-routes';
 import ToolsRoutes from './pages/tools/tools-routes';
@@ -8,7 +9,7 @@ import ToolsRoutes from './pages/tools/tools-routes';
 const AppRoutes: React.FC = () => {
   return (
     <Switch>
-      <Route exact path="/" component={DataRoutes} />
+      <Route exact path="/" component={AppHome} />
       <Route path="/data" component={DataRoutes} />
       <Route path="/plots" component={PlotsRoutes} />
       <Route path="/tools" component={ToolsRoutes} />

--- a/src/components/nav-sidebar/sidebar-button.tsx
+++ b/src/components/nav-sidebar/sidebar-button.tsx
@@ -58,7 +58,7 @@ const SidebarButton: React.FC<SidebarButtonProps> = ({
         color: 'gray.400',
       }}
       flexWrap="nowrap"
-      paddingX={6}
+      paddingX={5}
       paddingY={4}
       textColor="gray.600"
       onKeyDown={

--- a/src/components/nav-sidebar/sidebar-button.tsx
+++ b/src/components/nav-sidebar/sidebar-button.tsx
@@ -3,6 +3,8 @@ import { IconType } from 'react-icons';
 import { Flex, FlexProps, Icon, SpaceProps, Text } from '@chakra-ui/react';
 
 export interface SidebarButtonProps extends Omit<FlexProps, 'onClick'> {
+  /** @type whether the button is disabled */
+  disabled?: boolean;
   /** @type link icon */
   icon: IconType;
   /** @type on activation callback */
@@ -52,6 +54,9 @@ const SidebarButton: React.FC<SidebarButtonProps> = ({
       }}
       alignItems="center"
       as="button"
+      _disabled={{
+        color: 'gray.400',
+      }}
       flexWrap="nowrap"
       paddingX={6}
       paddingY={4}

--- a/src/components/nav-sidebar/sidebar-nav.tsx
+++ b/src/components/nav-sidebar/sidebar-nav.tsx
@@ -28,13 +28,14 @@ const SidebarNav: React.FC<React.PropsWithChildren<SidebarProps>> = (props) => {
       animate={{ x: 0 }}
       exit={{ x: -20 }}
     >
-      <Box role="region" aria-label="Sidebar actions" boxShadow="xl" {...props}>
+      <Box aria-label="Sidebar actions" boxShadow="xl" role="region" {...props}>
         <Stack
           _focusWithin={{
             width: props.maxWidth ?? '15rem',
           }}
           as="section"
           overflowX="hidden"
+          paddingX={1}
           paddingY="1rem"
           position="sticky"
           top={0}

--- a/src/components/nav-topbar/topbar-link.tsx
+++ b/src/components/nav-topbar/topbar-link.tsx
@@ -50,7 +50,12 @@ const ToolbarLink: React.FC<TopbarLinkProps> = (props): React.ReactElement => {
         to={props.href}
       >
         <Icon as={props.icon} width={5} height={5} />
-        <Text as="span" fontSize={fontSize} fontWeight="semibold">
+        <Text
+          as="span"
+          fontSize={fontSize}
+          fontWeight="semibold"
+          userSelect="none"
+        >
           {props.text}
         </Text>
       </SiteLink>

--- a/src/layouts/app-layout/app-layout.tsx
+++ b/src/layouts/app-layout/app-layout.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   FaChartBar,
-  FaHome,
+  // FaHome,
   FaInfo,
   FaDatabase,
   FaTools,
@@ -15,7 +15,7 @@ const AppLayout: React.FC<React.PropsWithChildren<{}>> = (
   return (
     <Flex flexDirection="column" minHeight="100vh" backgroundColor="gray.100">
       <TopbarNav>
-        <TopbarLink href="/" icon={FaHome} text="Home" urlMatch="exact" />
+        {/* <TopbarLink href="/" icon={FaHome} text="Home" urlMatch="exact" /> */}
         <TopbarLink
           href="/data"
           icon={FaDatabase}

--- a/src/pages/data/data-files.tsx
+++ b/src/pages/data/data-files.tsx
@@ -305,6 +305,8 @@ const DataFiles: React.FC = () => {
 
   /* REMOVE DATA */
 
+  const dataAvailable = dataTable.hasData;
+
   const bulkRemoveReplicates = (): void => {
     if (selectedReplicates.length > 0) {
       dataTable.removeColumns(...selectedReplicates);
@@ -349,6 +351,7 @@ const DataFiles: React.FC = () => {
           }
           icon={FaTrashAlt}
           onClick={bulkRemoveReplicates}
+          disabled={!dataAvailable}
         />
       </Sidebar>
 

--- a/src/pages/data/data-routes.tsx
+++ b/src/pages/data/data-routes.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
 import { Route, Switch, useRouteMatch } from 'react-router-dom';
 import DataFiles from './data-files';
-import DataHome from './data-home';
 
 const DataRoutes: React.FC = () => {
   const { path } = useRouteMatch();
 
   return (
     <Switch>
-      <Route exact path={path} component={DataHome} />
-      <Route exact path={path + '/files'} component={DataFiles} />
+      <Route exact path={path} component={DataFiles} />
     </Switch>
   );
 };

--- a/src/pages/plots/plots-home.tsx
+++ b/src/pages/plots/plots-home.tsx
@@ -3,14 +3,22 @@ import { FaBurn, FaChartBar, FaChartLine, FaTrashAlt } from 'react-icons/fa';
 import { FcLineChart } from 'react-icons/fc';
 import { MdBubbleChart } from 'react-icons/md';
 import { observer } from 'mobx-react';
+import {
+  Alert,
+  AlertIcon,
+  AlertTitle,
+  AlertDescription,
+  Flex,
+  Spinner,
+  useDisclosure,
+} from '@chakra-ui/react';
+import { FocusableElement } from '@chakra-ui/utils';
 
 import { dataTable, infoTable } from '@/store/data-store';
 import { plotStore } from '@/store/plot-store';
 
 import Sidebar, { SidebarButton } from '@/components/nav-sidebar';
 import FormikModal from '@/components/formik-modal';
-import { Flex, Spinner, useDisclosure } from '@chakra-ui/react';
-import { FocusableElement } from '@chakra-ui/utils';
 
 import { GxpHeatmap, PlotlyOptions, GxpPlotly, GxpPCA } from '@/types/plots';
 
@@ -226,6 +234,29 @@ const PlotsHome: React.FC = () => {
         marginLeft={20}
         overflow="hidden"
       >
+        {noDataAvailable && (
+          <Alert
+            alignItems="center"
+            flexDirection="column"
+            minHeight="16rem"
+            justifyContent="center"
+            marginLeft={3}
+            marginTop={3}
+            status="warning"
+            textAlign="center"
+            variant="subtle"
+          >
+            <AlertIcon boxSize="40px" mr={0} />
+            <AlertTitle mt={4} mb={1} fontSize="lg">
+              No data has been loaded
+            </AlertTitle>
+            <AlertDescription maxWidth="xl">
+              It seems no data has been loaded into the application yet. You can
+              load data from various formats in the Data section of the toolbar
+              above.
+            </AlertDescription>
+          </Alert>
+        )}
         {plotStore.plots.map((plot) => {
           if (plot.isLoading) {
             return (

--- a/src/pages/plots/plots-home.tsx
+++ b/src/pages/plots/plots-home.tsx
@@ -168,8 +168,8 @@ const PlotsHome: React.FC = () => {
     plotStore.clearPlots();
   };
 
-  const noDataAvailable = !dataTable.hasData;
-  const noPlotsAvailable = !plotStore.hasPlots;
+  const dataAvailable = dataTable.hasData;
+  const plotsAvailable = plotStore.hasPlots;
 
   return (
     <Flex as="main" flexGrow={1}>
@@ -186,42 +186,42 @@ const PlotsHome: React.FC = () => {
           text="Bars"
           icon={FaChartBar}
           onClick={onBarsFormOpen}
-          disabled={noDataAvailable}
+          disabled={!dataAvailable}
         />
 
         <SidebarButton
           text="Individual Lines"
           icon={FaChartLine}
           onClick={onIndividualLinesFormOpen}
-          disabled={noDataAvailable}
+          disabled={!dataAvailable}
         />
 
         <SidebarButton
           text="Stacked Lines"
           icon={FcLineChart}
           onClick={onStackedLinesFormOpen}
-          disabled={noDataAvailable}
+          disabled={!dataAvailable}
         />
 
         <SidebarButton
           text="Heatmap"
           icon={FaBurn}
           onClick={onHeatmapFormOpen}
-          disabled={noDataAvailable}
+          disabled={!dataAvailable}
         />
 
         <SidebarButton
           text="PCA"
           icon={MdBubbleChart}
           onClick={onPCAFormOpen}
-          disabled={noDataAvailable}
+          disabled={!dataAvailable}
         />
 
         <SidebarButton
           text="Remove All"
           icon={FaTrashAlt}
           onClick={onDeletePlots}
-          disabled={noPlotsAvailable}
+          disabled={!plotsAvailable}
         />
       </Sidebar>
 
@@ -234,11 +234,12 @@ const PlotsHome: React.FC = () => {
         marginLeft={20}
         overflow="hidden"
       >
-        {noDataAvailable && (
+        {!dataAvailable && (
           <Alert
             alignItems="center"
             flexDirection="column"
             minHeight="16rem"
+            maxHeight="20rem"
             justifyContent="center"
             marginLeft={3}
             marginTop={3}
@@ -246,7 +247,7 @@ const PlotsHome: React.FC = () => {
             textAlign="center"
             variant="subtle"
           >
-            <AlertIcon boxSize="40px" mr={0} />
+            <AlertIcon boxSize="3rem" mr={0} />
             <AlertTitle mt={4} mb={1} fontSize="lg">
               No data has been loaded
             </AlertTitle>

--- a/src/pages/plots/plots-home.tsx
+++ b/src/pages/plots/plots-home.tsx
@@ -221,7 +221,7 @@ const PlotsHome: React.FC = () => {
           text="Remove All"
           icon={FaTrashAlt}
           onClick={onDeletePlots}
-          disabled={noDataAvailable || noPlotsAvailable}
+          disabled={noPlotsAvailable}
         />
       </Sidebar>
 

--- a/src/pages/plots/plots-home.tsx
+++ b/src/pages/plots/plots-home.tsx
@@ -180,7 +180,7 @@ const PlotsHome: React.FC = () => {
         maxWidth="14rem"
         position="fixed"
         boxShadow="2xl"
-        zIndex="popover"
+        zIndex="overlay"
       >
         <SidebarButton
           text="Bars"

--- a/src/pages/plots/plots-home.tsx
+++ b/src/pages/plots/plots-home.tsx
@@ -4,8 +4,8 @@ import { FcLineChart } from 'react-icons/fc';
 import { MdBubbleChart } from 'react-icons/md';
 import { observer } from 'mobx-react';
 
+import { dataTable, infoTable } from '@/store/data-store';
 import { plotStore } from '@/store/plot-store';
-import { infoTable } from '@/store/data-store';
 
 import Sidebar, { SidebarButton } from '@/components/nav-sidebar';
 import FormikModal from '@/components/formik-modal';
@@ -160,6 +160,9 @@ const PlotsHome: React.FC = () => {
     plotStore.clearPlots();
   };
 
+  const noDataAvailable = !dataTable.hasData;
+  const noPlotsAvailable = !plotStore.hasPlots;
+
   return (
     <Flex as="main" flexGrow={1}>
       <Sidebar
@@ -171,36 +174,46 @@ const PlotsHome: React.FC = () => {
         boxShadow="2xl"
         zIndex="popover"
       >
-        <SidebarButton text="Bars" icon={FaChartBar} onClick={onBarsFormOpen} />
+        <SidebarButton
+          text="Bars"
+          icon={FaChartBar}
+          onClick={onBarsFormOpen}
+          disabled={noDataAvailable}
+        />
 
         <SidebarButton
           text="Individual Lines"
           icon={FaChartLine}
           onClick={onIndividualLinesFormOpen}
+          disabled={noDataAvailable}
         />
 
         <SidebarButton
           text="Stacked Lines"
           icon={FcLineChart}
           onClick={onStackedLinesFormOpen}
+          disabled={noDataAvailable}
         />
 
         <SidebarButton
           text="Heatmap"
           icon={FaBurn}
           onClick={onHeatmapFormOpen}
+          disabled={noDataAvailable}
         />
 
         <SidebarButton
           text="PCA"
           icon={MdBubbleChart}
           onClick={onPCAFormOpen}
+          disabled={noDataAvailable}
         />
 
         <SidebarButton
           text="Remove All"
           icon={FaTrashAlt}
           onClick={onDeletePlots}
+          disabled={noDataAvailable || noPlotsAvailable}
         />
       </Sidebar>
 

--- a/src/pages/tools/components/gene-browser.tsx
+++ b/src/pages/tools/components/gene-browser.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
 import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  AlertTitle,
   Button,
   Flex,
   Modal,
@@ -130,6 +134,8 @@ const GeneBrowser: React.FC = () => {
     }, 10);
   };
 
+  const dataAvailable = dataTable.hasData;
+
   return (
     <Flex
       flexDirection="column"
@@ -145,7 +151,30 @@ const GeneBrowser: React.FC = () => {
         pageMax={pageView.pageMax}
       />
 
-      {pageLoading ? (
+      {!dataAvailable ? (
+        <Alert
+          alignItems="center"
+          flexDirection="column"
+          minHeight="16rem"
+          maxHeight="20rem"
+          justifyContent="center"
+          marginLeft={3}
+          marginTop={3}
+          status="warning"
+          textAlign="center"
+          variant="subtle"
+        >
+          <AlertIcon boxSize="3rem" mr={0} />
+          <AlertTitle mt={4} mb={1} fontSize="lg">
+            No data has been loaded
+          </AlertTitle>
+          <AlertDescription maxWidth="xl">
+            It seems no data has been loaded into the application yet. You can
+            load data from various formats in the Data section of the toolbar
+            above.
+          </AlertDescription>
+        </Alert>
+      ) : pageLoading ? (
         <Flex
           width="100%"
           flexGrow={1}


### PR DESCRIPTION
## Summary

This PR implements several tweaks and fixes to page layouts and UI flow mechanisms.

## Changes
- Remove the `data-home` page from the router and load `data-files` instead.
- Remove the empty home page and load the `data-files` page instead.
- Disable buttons in the sidebar actions of `data-files` and `plots-home`, as appropriate.
- Warn the user when in the `plots-home` page and no data has been loaded.
- Warn the user when in the `gene-browser` page and no data has been loaded.
- Prevent the text of the application navigation bar buttons from being selected (it was causing mis-navigation events).
- Fix the now floating actions sidebar in `plots-home` from being selectable when a modal is open.