### PR TITLE
feat: Info routes

### DIFF
--- a/src/app-routes.tsx
+++ b/src/app-routes.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 
 import DataRoutes from './pages/data/data-routes';
+import InfoRoutes from './pages/info/info-routes';
 import PlotsRoutes from './pages/plots/plots-routes';
 import ToolsRoutes from './pages/tools/tools-routes';
 
@@ -11,6 +12,7 @@ const AppRoutes: React.FC = () => {
       <Route path="/data" component={DataRoutes} />
       <Route path="/plots" component={PlotsRoutes} />
       <Route path="/tools" component={ToolsRoutes} />
+      <Route path="/docs" component={InfoRoutes} />
     </Switch>
   );
 };

--- a/src/components/link-card/index.ts
+++ b/src/components/link-card/index.ts
@@ -1,0 +1,4 @@
+import LinkCard from './link-card';
+
+export * from './link-card';
+export default LinkCard;

--- a/src/components/link-card/link-card.tsx
+++ b/src/components/link-card/link-card.tsx
@@ -1,0 +1,92 @@
+import { motion } from 'framer-motion';
+import React from 'react';
+import { IconType } from 'react-icons';
+import { FaArrowRight } from 'react-icons/fa';
+import { Box, BoxProps, Flex, FlexProps, Icon, Text } from '@chakra-ui/react';
+import { Link, LinkProps } from '@chakra-ui/react';
+
+interface LinkCardProps extends LinkProps {
+  label: string;
+  text: string;
+  icon?: IconType;
+}
+
+const MotionFlex = motion<FlexProps>(Flex);
+const MotionBox = motion<BoxProps>(Box);
+
+const LinkCard: React.FC<LinkCardProps> = ({ label, text, icon, ...props }) => {
+  return (
+    <Link
+      {...props}
+      _focus={{
+        outline: 'none',
+        borderLeftColor: 'orange.600',
+        ...props._focus,
+      }}
+      _hover={{
+        borderLeftColor: 'orange.600',
+        boxShadow: 'md',
+        textDecoration: 'none',
+        ...props._hover,
+      }}
+      backgroundColor="white"
+      borderLeft="4px"
+      borderLeftColor="transparent"
+      boxShadow="xs"
+      display="flex"
+      padding={5}
+      rel="noopener noreferrer"
+      target="_blank"
+      tabIndex={0}
+      width="100%"
+    >
+      {icon && (
+        <Icon
+          as={icon}
+          color="gray.600"
+          height="1.5rem"
+          marginTop={1}
+          marginRight="1rem"
+          width="1.5rem"
+        />
+      )}
+
+      <MotionFlex
+        as="section"
+        alignItems="center"
+        flexGrow={1}
+        whileHover="hover"
+      >
+        <Box width="100%">
+          <Text as="h1" fontSize="xl" fontWeight="semibold">
+            {label}
+          </Text>
+          <Text marginTop="1.5">{text}</Text>
+        </Box>
+
+        <MotionBox
+          marginX="1rem"
+          variants={{
+            hover: {
+              x: [0, 10],
+              transition: {
+                duration: 0.8,
+                repeat: Infinity,
+                repeatType: 'mirror',
+              },
+            },
+          }}
+        >
+          <Icon
+            as={FaArrowRight}
+            color="orange.600"
+            height="1.5rem"
+            width="1.5rem"
+          />
+        </MotionBox>
+      </MotionFlex>
+    </Link>
+  );
+};
+
+export default LinkCard;

--- a/src/pages/info/info-home.tsx
+++ b/src/pages/info/info-home.tsx
@@ -19,7 +19,7 @@ const DataHome: React.FC = () => {
         icon={FaBookReader}
         label="User Manual"
         text={`
-          The user manual contains detailed information on how to to load data
+          The user manual contains detailed information on how to load data
           and create new plots. All the data loaded in the application is kept
           private to your browser tab and will never be uploaded to the
           internet.

--- a/src/pages/info/info-home.tsx
+++ b/src/pages/info/info-home.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Box } from '@chakra-ui/react';
+import LinkCard from '@/components/link-card';
+import { FaBookReader, FaCode } from 'react-icons/fa';
+
+const DataHome: React.FC = () => {
+  return (
+    <Box
+      as="main"
+      padding={6}
+      width="100%"
+      __css={{
+        '& a:not(:first-of-type)': {
+          marginTop: '2rem',
+        },
+      }}
+    >
+      <LinkCard
+        icon={FaBookReader}
+        label="User Manual"
+        text={`
+          The user manual contains detailed information on how to to load data
+          and create new plots. All the data loaded in the application is kept
+          private to your browser tab and will never be uploaded to the
+          internet.
+        `}
+        href="https://zendro-dev.gitbook.io/geneexpressionplots/documentation/user-manual"
+      />
+      <LinkCard
+        _hover={{
+          textDecoration: 'none',
+        }}
+        icon={FaCode}
+        label="API"
+        text={`
+          The application programming interface contains instructions for
+          advanced users that want to deploy this application with data
+          already pre-loaded. This type of deployment is useful to showcase
+          public datasets.
+        `}
+        href="https://zendro-dev.gitbook.io/geneexpressionplots/documentation/api"
+      />
+    </Box>
+  );
+};
+
+export default DataHome;

--- a/src/pages/info/info-routes.tsx
+++ b/src/pages/info/info-routes.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Route, Switch, useRouteMatch } from 'react-router-dom';
+
+import InfoHome from './info-home';
+
+const InfoRoutes: React.FC = () => {
+  const { path } = useRouteMatch();
+
+  return (
+    <Switch>
+      <Route exact path={path} component={InfoHome} />
+    </Switch>
+  );
+};
+
+export default InfoRoutes;


### PR DESCRIPTION
# Summary

This PR adds documentation content to the info route. For now a collection of link cards that refer to the appropriate github pages.

## Changes
- Add a new `link-card` component similar in style to the `nav-link`.
- Add a new `info-page` and integrate in the application routes.