### PR TITLE
feat: accession validation

### DIFF
--- a/src/pages/plots/components/bars-form.tsx
+++ b/src/pages/plots/components/bars-form.tsx
@@ -20,6 +20,7 @@ import {
 } from '@chakra-ui/react';
 import FormikSwitch from '@/components/formik-switch';
 import FormikAccession from '@/components/formik-accession';
+import { dataTable } from '@/store/data-store';
 
 export interface BarsFormAttributes {
   accessions: string[];
@@ -41,6 +42,8 @@ export interface BarsFormProps {
 
 const BarsForm: React.FC<BarsFormProps> = (props) => {
   const validateAccession: FieldValidator = (value: string) => {
+    const row = dataTable.getRow(value);
+    if (!row) return 'The accession ID does not exist';
     if (!value) return 'The accession ID cannot be empty';
   };
 

--- a/src/pages/plots/components/bars-form.tsx
+++ b/src/pages/plots/components/bars-form.tsx
@@ -56,6 +56,7 @@ const BarsForm: React.FC<BarsFormProps> = (props) => {
         withLegend: true,
       }}
       onSubmit={props.onSubmit}
+      validateOnBlur={false}
     >
       {(formProps) => (
         <Box as={Form}>

--- a/src/pages/plots/components/individual-lines-form.tsx
+++ b/src/pages/plots/components/individual-lines-form.tsx
@@ -20,6 +20,7 @@ import {
 } from '@chakra-ui/react';
 import { FocusableElement } from '@chakra-ui/utils';
 import FormikSwitch from '@/components/formik-switch';
+import { dataTable } from '@/store/data-store';
 
 export interface IndividualLinesAttributes {
   accessions: string[];
@@ -41,6 +42,8 @@ export interface IndividualLinesFormProps {
 
 const IndividualLinesForm: React.FC<IndividualLinesFormProps> = (props) => {
   const validateAccession: FieldValidator = (value: string) => {
+    const row = dataTable.getRow(value);
+    if (!row) return 'The accession ID does not exist';
     if (!value) return 'The accession ID cannot be empty';
   };
 

--- a/src/pages/plots/components/individual-lines-form.tsx
+++ b/src/pages/plots/components/individual-lines-form.tsx
@@ -56,6 +56,7 @@ const IndividualLinesForm: React.FC<IndividualLinesFormProps> = (props) => {
         withLegend: true,
       }}
       onSubmit={props.onSubmit}
+      validateOnBlur={false}
     >
       {(formProps) => (
         <Box as={Form}>

--- a/src/pages/plots/components/stacked-lines-form.tsx
+++ b/src/pages/plots/components/stacked-lines-form.tsx
@@ -20,6 +20,7 @@ import {
 } from '@chakra-ui/react';
 import { FocusableElement } from '@chakra-ui/utils';
 import FormikSwitch from '@/components/formik-switch';
+import { dataTable } from '@/store/data-store';
 
 export interface StackedLinesAttributes {
   accessions: string[];
@@ -41,6 +42,8 @@ export interface StackedLinesFormProps {
 
 const StackedLinesForm: React.FC<StackedLinesFormProps> = (props) => {
   const validateAccession: FieldValidator = (value: string) => {
+    const row = dataTable.getRow(value);
+    if (!row) return 'The accession ID does not exist';
     if (!value) return 'The accession ID cannot be empty';
   };
 

--- a/src/pages/plots/components/stacked-lines-form.tsx
+++ b/src/pages/plots/components/stacked-lines-form.tsx
@@ -56,6 +56,7 @@ const StackedLinesForm: React.FC<StackedLinesFormProps> = (props) => {
         withLegend: true,
       }}
       onSubmit={props.onSubmit}
+      validateOnBlur={false}
     >
       {(formProps) => (
         <Box as={Form}>


### PR DESCRIPTION
## Summary

This PR adds a validation step to plot accession inputs, to verify that the current accession exists in the database. Additionally, it disables input validation `onBlur`, as it was causing UX issues when trying to cancel the form.

## Changes
- Add an additional validation check to `validateAccession`.
- Set `validateOnBlur` to `false` in plot forms that did not have it.