### PR TITLE
fix: missing validateOnBlur for data forms

### DIFF
--- a/src/pages/data/components/export-form.tsx
+++ b/src/pages/data/components/export-form.tsx
@@ -57,6 +57,7 @@ const ExportGXPForm: React.FC<ExportGXPFormProps> = (props) => {
         fileName: 'GXP_Database',
       }}
       onSubmit={props.onSubmit}
+      validateOnBlur={false}
     >
       {(formProps) => (
         <Box

--- a/src/pages/data/components/import-form.tsx
+++ b/src/pages/data/components/import-form.tsx
@@ -46,7 +46,7 @@ const ImportGXPForm: React.FC<ImportGXPFormProps> = (props) => {
   };
 
   return (
-    <Formik initialValues={{}} onSubmit={props.onSubmit}>
+    <Formik initialValues={{}} onSubmit={props.onSubmit} validateOnBlur={false}>
       {(formProps) => (
         <Box
           as={Form}

--- a/src/pages/data/components/info-form.tsx
+++ b/src/pages/data/components/info-form.tsx
@@ -55,6 +55,7 @@ const InfoForm: React.FC<InfoFormProps> = (props) => {
         columnSep: '\\t',
       }}
       onSubmit={props.onSubmit}
+      validateOnBlur={false}
     >
       {(formProps) => (
         <Box

--- a/src/pages/data/components/xtable-form.tsx
+++ b/src/pages/data/components/xtable-form.tsx
@@ -59,6 +59,7 @@ const XTableForm: React.FC<XTableFormProps> = (props) => {
         columnSep: '\\t',
       }}
       onSubmit={props.onSubmit}
+      validateOnBlur={false}
     >
       {(formProps) => (
         <Box


### PR DESCRIPTION
## Summary

This PR adds missing `validateOnBlur={false}` to data forms to fix being able to cancel without triggering validation.