### PR TITLE
feat: color by for stacked lines form

### DIFF
--- a/src/components/formik-radio/formik-radio.tsx
+++ b/src/components/formik-radio/formik-radio.tsx
@@ -1,0 +1,80 @@
+import { FieldValidator, useField } from 'formik';
+import React from 'react';
+import {
+  FormControl,
+  FormControlProps,
+  FormLabel,
+  FormErrorMessage,
+  Input,
+  InputGroup,
+  InputGroupProps,
+  InputProps,
+  VisuallyHidden,
+  Radio,
+  RadioGroup,
+  UseRadioGroupProps,
+  Stack,
+} from '@chakra-ui/react';
+import { FocusableElement } from '@chakra-ui/utils';
+
+interface FormikRadioProps extends InputProps {
+  name: string;
+  label: string;
+  hideLabel?: boolean;
+  controlProps?: FormControlProps;
+  validate?: FieldValidator;
+}
+
+const FormikRadio: React.FC<FormikRadioProps> = ({
+  controlProps,
+  hideLabel,
+  label,
+  name,
+  validate,
+  ...props
+}) => {
+  const [field, meta, helpers] = useField({
+    name,
+    validate,
+  });
+
+  const handleOnChange: UseRadioGroupProps['onChange'] = (nextValue) => {
+    console.log({ nextValue });
+    helpers.setValue(nextValue);
+  };
+
+  console.log({ field, meta });
+
+  return (
+    <FormControl
+      {...controlProps}
+      isInvalid={meta.error !== undefined && meta.touched !== undefined}
+      isRequired={props.isRequired}
+    >
+      {hideLabel ? (
+        <VisuallyHidden>
+          <FormLabel fontWeight="semibold">{label}</FormLabel>
+        </VisuallyHidden>
+      ) : (
+        <FormLabel fontWeight="semibold">{label}</FormLabel>
+      )}
+      <RadioGroup
+        name={field.name}
+        value={field.value}
+        onChange={handleOnChange}
+      >
+        <Stack direction="row">
+          <Radio value="group" colorScheme="orange">
+            Group
+          </Radio>
+          <Radio value="accession" colorScheme="orange">
+            Accession
+          </Radio>
+        </Stack>
+      </RadioGroup>
+      <FormErrorMessage as="span">{meta.error}</FormErrorMessage>
+    </FormControl>
+  );
+};
+
+export default FormikRadio;

--- a/src/components/formik-radio/formik-radio.tsx
+++ b/src/components/formik-radio/formik-radio.tsx
@@ -5,12 +5,12 @@ import {
   FormControlProps,
   FormLabel,
   FormErrorMessage,
-  InputProps,
   VisuallyHidden,
   Radio,
   RadioGroup,
   UseRadioGroupProps,
   Stack,
+  StackDirection,
 } from '@chakra-ui/react';
 
 interface RadioField {
@@ -19,22 +19,24 @@ interface RadioField {
   disabled: boolean;
 }
 
-interface FormikRadioProps extends InputProps {
-  name: string;
-  label: string;
-  hideLabel?: boolean;
+interface FormikRadioProps {
   controlProps?: FormControlProps;
-  validate?: FieldValidator;
+  direction?: StackDirection;
+  hideLabel?: boolean;
+  label: string;
+  name: string;
   options: RadioField[];
+  validate?: FieldValidator;
 }
 
 const FormikRadio: React.FC<FormikRadioProps> = ({
   controlProps,
+  direction,
   hideLabel,
   label,
   name,
+  options,
   validate,
-  ...props
 }) => {
   const [field, meta, helpers] = useField({
     name,
@@ -49,7 +51,6 @@ const FormikRadio: React.FC<FormikRadioProps> = ({
     <FormControl
       {...controlProps}
       isInvalid={meta.error !== undefined && meta.touched !== undefined}
-      isRequired={props.isRequired}
     >
       {hideLabel ? (
         <VisuallyHidden>
@@ -63,8 +64,8 @@ const FormikRadio: React.FC<FormikRadioProps> = ({
         value={field.value}
         onChange={handleOnChange}
       >
-        <Stack direction="row">
-          {props.options.map((option, index) => (
+        <Stack direction={direction}>
+          {options.map((option, index) => (
             <Radio
               colorScheme="orange"
               key={`${option.label}-${index}`}

--- a/src/components/formik-radio/formik-radio.tsx
+++ b/src/components/formik-radio/formik-radio.tsx
@@ -5,9 +5,6 @@ import {
   FormControlProps,
   FormLabel,
   FormErrorMessage,
-  Input,
-  InputGroup,
-  InputGroupProps,
   InputProps,
   VisuallyHidden,
   Radio,
@@ -15,7 +12,12 @@ import {
   UseRadioGroupProps,
   Stack,
 } from '@chakra-ui/react';
-import { FocusableElement } from '@chakra-ui/utils';
+
+interface RadioField {
+  label: string;
+  value: string;
+  disabled: boolean;
+}
 
 interface FormikRadioProps extends InputProps {
   name: string;
@@ -23,6 +25,7 @@ interface FormikRadioProps extends InputProps {
   hideLabel?: boolean;
   controlProps?: FormControlProps;
   validate?: FieldValidator;
+  options: RadioField[];
 }
 
 const FormikRadio: React.FC<FormikRadioProps> = ({
@@ -39,11 +42,8 @@ const FormikRadio: React.FC<FormikRadioProps> = ({
   });
 
   const handleOnChange: UseRadioGroupProps['onChange'] = (nextValue) => {
-    console.log({ nextValue });
     helpers.setValue(nextValue);
   };
-
-  console.log({ field, meta });
 
   return (
     <FormControl
@@ -64,12 +64,16 @@ const FormikRadio: React.FC<FormikRadioProps> = ({
         onChange={handleOnChange}
       >
         <Stack direction="row">
-          <Radio value="group" colorScheme="orange">
-            Group
-          </Radio>
-          <Radio value="accession" colorScheme="orange">
-            Accession
-          </Radio>
+          {props.options.map((option, index) => (
+            <Radio
+              colorScheme="orange"
+              key={`${option.label}-${index}`}
+              value={option.value}
+              isDisabled={option.disabled}
+            >
+              {option.label}
+            </Radio>
+          ))}
         </Stack>
       </RadioGroup>
       <FormErrorMessage as="span">{meta.error}</FormErrorMessage>

--- a/src/components/formik-radio/formik-radio.tsx
+++ b/src/components/formik-radio/formik-radio.tsx
@@ -11,11 +11,11 @@ import {
   UseRadioGroupProps,
   Stack,
   StackDirection,
+  RadioProps,
 } from '@chakra-ui/react';
 
-interface RadioField {
+interface RadioOptions extends RadioProps {
   label: string;
-  value: string;
   disabled: boolean;
 }
 
@@ -25,7 +25,7 @@ interface FormikRadioProps {
   hideLabel?: boolean;
   label: string;
   name: string;
-  options: RadioField[];
+  options: RadioOptions[];
   validate?: FieldValidator;
 }
 
@@ -71,6 +71,7 @@ const FormikRadio: React.FC<FormikRadioProps> = ({
               key={`${option.label}-${index}`}
               value={option.value}
               isDisabled={option.disabled}
+              {...option}
             >
               {option.label}
             </Radio>

--- a/src/components/formik-radio/index.ts
+++ b/src/components/formik-radio/index.ts
@@ -1,0 +1,3 @@
+import FormikRadio from './formik-radio';
+
+export default FormikRadio;

--- a/src/pages/plots/components/stacked-lines-form.tsx
+++ b/src/pages/plots/components/stacked-lines-form.tsx
@@ -106,6 +106,7 @@ const StackedLinesForm: React.FC<StackedLinesFormProps> = (props) => {
               as: 'p',
               marginTop: '1rem',
             }}
+            direction="row"
             label="Color by"
             name="colorBy"
             options={[

--- a/src/pages/plots/components/stacked-lines-form.tsx
+++ b/src/pages/plots/components/stacked-lines-form.tsx
@@ -101,25 +101,6 @@ const StackedLinesForm: React.FC<StackedLinesFormProps> = (props) => {
             name="plotTitle"
           />
 
-          {/* <FormControl as="p" marginTop="1rem">
-            <FormLabel fontWeight="semibold">Color by</FormLabel>
-            <RadioGroup
-              value={
-                formProps.values.accessions.length === 1 ? 'group' : field.value
-              }
-              onChange={field.onChange}
-            >
-              <Stack direction="row">
-                <Radio value="group">Group</Radio>
-                <Radio
-                  value="accession"
-                  isDisabled={formProps.values.accessions.length === 1}
-                >
-                  Accession
-                </Radio>
-              </Stack>
-            </RadioGroup>
-          </FormControl> */}
           <FormikRadio
             controlProps={{
               as: 'p',
@@ -127,14 +108,15 @@ const StackedLinesForm: React.FC<StackedLinesFormProps> = (props) => {
             }}
             label="Color by"
             name="colorBy"
+            options={[
+              { label: 'Group', value: 'group', disabled: false },
+              {
+                label: 'Accession',
+                value: 'accession',
+                disabled: formProps.values.accessions.length === 1,
+              },
+            ]}
           ></FormikRadio>
-
-          {/* <FormikSelect
-            controlProps={{ as: 'p', marginTop: '1rem' }}
-            name="colorBy"
-            label="Color by"
-            id="yap"
-          ></FormikSelect> */}
 
           <FieldArray name="accessions">
             {(helpers) => (

--- a/src/pages/plots/components/stacked-lines-form.tsx
+++ b/src/pages/plots/components/stacked-lines-form.tsx
@@ -21,12 +21,14 @@ import {
 import { FocusableElement } from '@chakra-ui/utils';
 import FormikSwitch from '@/components/formik-switch';
 import { dataTable } from '@/store/data-store';
+import FormikRadio from '@/components/formik-radio';
 
 export interface StackedLinesAttributes {
   accessions: string[];
   plotTitle: string;
   withCaption: boolean;
   withLegend: boolean;
+  colorBy: 'group' | 'accession';
 }
 
 export type StackedLinesFormSubmitHandler = (
@@ -54,6 +56,7 @@ const StackedLinesForm: React.FC<StackedLinesFormProps> = (props) => {
         plotTitle: '',
         withCaption: true,
         withLegend: true,
+        colorBy: 'group',
       }}
       onSubmit={props.onSubmit}
       validateOnBlur={false}
@@ -97,6 +100,41 @@ const StackedLinesForm: React.FC<StackedLinesFormProps> = (props) => {
             label="Plot Title"
             name="plotTitle"
           />
+
+          {/* <FormControl as="p" marginTop="1rem">
+            <FormLabel fontWeight="semibold">Color by</FormLabel>
+            <RadioGroup
+              value={
+                formProps.values.accessions.length === 1 ? 'group' : field.value
+              }
+              onChange={field.onChange}
+            >
+              <Stack direction="row">
+                <Radio value="group">Group</Radio>
+                <Radio
+                  value="accession"
+                  isDisabled={formProps.values.accessions.length === 1}
+                >
+                  Accession
+                </Radio>
+              </Stack>
+            </RadioGroup>
+          </FormControl> */}
+          <FormikRadio
+            controlProps={{
+              as: 'p',
+              marginTop: '1rem',
+            }}
+            label="Color by"
+            name="colorBy"
+          ></FormikRadio>
+
+          {/* <FormikSelect
+            controlProps={{ as: 'p', marginTop: '1rem' }}
+            name="colorBy"
+            label="Color by"
+            id="yap"
+          ></FormikSelect> */}
 
           <FieldArray name="accessions">
             {(helpers) => (

--- a/src/pages/plots/plots-home.tsx
+++ b/src/pages/plots/plots-home.tsx
@@ -115,11 +115,12 @@ const PlotsHome: React.FC = () => {
     values,
     actions
   ) => {
+    console.log({ cb: values.colorBy });
     plotStore.addStackedLinesPlot(values.accessions, {
       showlegend: values.withLegend,
       showCaption: values.withCaption,
       plotTitle: values.plotTitle,
-      colorBy: 'group',
+      colorBy: values.colorBy,
     } as PlotlyOptions);
 
     actions.setSubmitting(false);

--- a/src/pages/plots/plots-home.tsx
+++ b/src/pages/plots/plots-home.tsx
@@ -115,7 +115,6 @@ const PlotsHome: React.FC = () => {
     values,
     actions
   ) => {
-    console.log({ cb: values.colorBy });
     plotStore.addStackedLinesPlot(values.accessions, {
       showlegend: values.withLegend,
       showCaption: values.withCaption,

--- a/src/utils/plots/stacked-lines.ts
+++ b/src/utils/plots/stacked-lines.ts
@@ -28,6 +28,7 @@ const stackedLinesData = (
   accessions: string[],
   options: PlotlyOptions
 ): Partial<PlotData>[] => {
+  console.log({ options });
   const data: Partial<PlotData>[] = [];
   let colorIndex = 0;
   let styleIndex = 0;

--- a/src/utils/plots/stacked-lines.ts
+++ b/src/utils/plots/stacked-lines.ts
@@ -28,7 +28,6 @@ const stackedLinesData = (
   accessions: string[],
   options: PlotlyOptions
 ): Partial<PlotData>[] => {
-  console.log({ options });
   const data: Partial<PlotData>[] = [];
   let colorIndex = 0;
   let styleIndex = 0;


### PR DESCRIPTION
## Summary

This PR implements the colorBy `group` or `accession` feature for stacked line plots

## Changes
- add generic reusable `form-radio` component
- use the component in the stacked-lines form