### PR TITLE
feat: app state

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,15 @@
 import React from 'react';
 import { HashRouter } from 'react-router-dom';
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  AlertTitle,
+  Code,
+  Flex,
+  Spinner,
+  Text,
+} from '@chakra-ui/react';
 
 import AppRoutes from './app-routes';
 import AppLayout from './layouts/app-layout';
@@ -11,75 +21,144 @@ import { dataTable, infoTable } from '@/store/data-store';
 import { plotStore } from './store/plot-store';
 import { settings } from '@/store/settings';
 
+type AppState = 'failed' | 'idle' | 'loading';
+
 const App: React.FC = () => {
-  React.useEffect(function preloadSettings() {
-    if (settings.preloaded.settings) {
-      fetchResource(settings.preloaded.settings, 'json').then(
-        (settingsResponse) => {
-          if (settingsResponse) {
-            settings.loadgxpSettings(settingsResponse);
-            plotStore.loadCountUnit(settings.gxpSettings.unit);
-          }
-        }
-      );
-    }
-  }, []);
+  const [appState, setAppState] = React.useState<{
+    status: AppState;
+    message?: string;
+  }>({
+    status: 'idle',
+  });
 
-  React.useEffect(function preloadData() {
-    if (settings.preloaded.data) {
-      fetchResource(settings.preloaded.data, 'text').then((dataResponse) => {
-        if (dataResponse)
-          dataTable.loadFromObject(
-            readTable(dataResponse, {
-              fieldSeparator: settings.gxpSettings.expression_field_sep,
-              rowNameColumn: 0,
-            }),
-            {
-              multiHeader: settings.gxpSettings.expression_header_sep,
-            }
-          );
+  const preload = async (): Promise<void> => {
+    setAppState({ status: 'loading' });
+    try {
+      // Preload Settings
+      if (settings.preloaded.settings) {
+        const settingsResponse = await fetchResource(
+          settings.preloaded.settings,
+          'json'
+        );
+
+        settings.loadgxpSettings(settingsResponse);
+        plotStore.loadCountUnit(settings.gxpSettings.unit);
+      }
+
+      // Preload Data
+      if (settings.preloaded.data) {
+        const dataResponse = await fetchResource(
+          settings.preloaded.data,
+          'text'
+        );
+
+        const table = readTable(dataResponse, {
+          fieldSeparator: settings.gxpSettings.expression_field_sep,
+          rowNameColumn: 0,
+        });
+
+        dataTable.loadFromObject(table, {
+          multiHeader: settings.gxpSettings.expression_header_sep,
+        });
+
+        // If a custom sorting is not provided for groups and samples, use the
+        // table column order.
+        if (settings.gxpSettings.groupOrder.length === 0)
+          settings.setGroupOrder(dataTable.groupsAsArray);
+        if (settings.gxpSettings.sampleOrder.length === 0)
+          settings.setSampleOrder(dataTable.samplesAsArray);
+      }
+
+      // Preload Info
+      if (settings.preloaded.info) {
+        const infoResponse = await fetchResource(
+          settings.preloaded.info,
+          'text'
+        );
+        const table = readTable(infoResponse, {
+          fieldSeparator: settings.gxpSettings.info_field_sep,
+          rowNameColumn: 0,
+        });
+
+        infoTable.loadFromObject(table, { multiHeader: '*' });
+      }
+
+      // Preload image
+      if (settings.preloaded.image) {
+        const url = await fetchResource(settings.preloaded.image, 'url');
+        // Use the file name for the "alt" attribute
+        const alt = url.split('/').pop()?.split('.').shift() as string;
+        plotStore.addImagePlot(url, alt);
+      }
+      setAppState({
+        status: 'idle',
       });
-
-      // If a custom sorting is not provided for groups and samples, use the
-      // table column order.
-      if (settings.gxpSettings.groupOrder.length === 0)
-        settings.setGroupOrder(dataTable.groupsAsArray);
-      if (settings.gxpSettings.sampleOrder.length === 0)
-        settings.setSampleOrder(dataTable.samplesAsArray);
-    }
-  }, []);
-
-  React.useEffect(function preloadInfo() {
-    if (settings.preloaded.info) {
-      fetchResource(settings.preloaded.info, 'text').then((infoResponse) => {
-        if (infoResponse) {
-          const table = readTable(infoResponse, {
-            fieldSeparator: settings.gxpSettings.info_field_sep,
-            rowNameColumn: 0,
-          });
-
-          infoTable.loadFromObject(table, { multiHeader: '*' });
-        }
+    } catch (error) {
+      setAppState({
+        status: 'failed',
+        message: error.message,
       });
     }
-  }, []);
+  };
 
-  React.useEffect(function preloadImage() {
-    if (settings.preloaded.image) {
-      fetchResource(settings.preloaded.image, 'url').then((url) => {
-        if (url) {
-          // Use the file name for the "alt" attribute
-          const alt = url.split('/').pop()?.split('.').shift() as string;
-          plotStore.addImagePlot(url, alt);
-        }
-      });
+  React.useEffect(function preloadApp() {
+    if (
+      settings.preloaded.data ||
+      settings.preloaded.image ||
+      settings.preloaded.info ||
+      settings.preloaded.settings
+    ) {
+      preload();
     }
   }, []);
 
   return (
     <HashRouter>
       <AppLayout>
-        <AppRoutes />
+        {appState.status === 'loading' ? (
+          <Flex
+            alignItems="center"
+            flexDirection="column"
+            flexGrow={1}
+            justifyContent="center"
+            width="100%"
+          >
+            <Spinner
+              thickness="4px"
+              speed="0.65s"
+              emptyColor="gray.200"
+              color="blue.500"
+              size="xl"
+            />
+            <Text fontSize="xl" fontWeight="semibold" marginTop={6}>
+              Loading Application Data
+            </Text>
+          </Flex>
+        ) : appState.status === 'failed' ? (
+          <Alert
+            alignItems="center"
+            flexDirection="column"
+            justifyContent="center"
+            marginTop={10}
+            padding={8}
+            status="error"
+            textAlign="center"
+            variant="subtle"
+          >
+            <AlertIcon boxSize="2rem" marginRight={0} />
+            <AlertTitle marginTop={6} fontSize="lg">
+              The application failed to load
+            </AlertTitle>
+            <AlertDescription marginTop={3} maxWidth="xl">
+              The application failed when trying to load data resources. You may
+              try reloading the page. If the problem persists, please contact
+              your administrator.
+            </AlertDescription>
+            <Code marginTop={6}>{appState.message}</Code>
+          </Alert>
+        ) : (
+          <AppRoutes />
+        )}
       </AppLayout>
     </HashRouter>
   );

--- a/src/layouts/app-layout/app-layout.tsx
+++ b/src/layouts/app-layout/app-layout.tsx
@@ -6,14 +6,19 @@ import {
   FaDatabase,
   FaTools,
 } from 'react-icons/fa';
-import { Flex } from '@chakra-ui/react';
+import { Flex, FlexProps } from '@chakra-ui/react';
 import TopbarNav, { TopbarLink } from '@/components/nav-topbar';
 
-const AppLayout: React.FC<React.PropsWithChildren<{}>> = (
-  props
-): React.ReactElement => {
+type AppLayoutProps = FlexProps;
+
+const AppLayout: React.FC<AppLayoutProps> = (props) => {
   return (
-    <Flex flexDirection="column" minHeight="100vh" backgroundColor="gray.100">
+    <Flex
+      flexDirection="column"
+      minHeight="100vh"
+      backgroundColor="gray.100"
+      {...props}
+    >
       <TopbarNav>
         {/* <TopbarLink href="/" icon={FaHome} text="Home" urlMatch="exact" /> */}
         <TopbarLink

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,49 +1,54 @@
 /**
  * Fetch a statically served resource and parse it a Blob.
- * @param file public resource to fetch
+ * @param resource resource to fetch
  * @param type resource conversion type
  * @param init request options
  * @returns the fetched resource
  */
 export async function fetchResource(
-  file: string,
-  type: 'blob'
-): Promise<Blob | undefined>;
+  resource: string,
+  type: 'blob',
+  init?: RequestInit
+): Promise<Blob>;
 
 /**
  * Fetch a statically served resource and parse it as JSON.
- * @param file public resource to fetch
+ * @param resource resource to fetch
  * @param type resource conversion type
  * @param init request options
  * @returns the fetched resource
  */
-export async function fetchResource(
-  file: string,
-  type: 'json'
-): Promise<Record<string, unknown> | undefined>;
+export async function fetchResource<T = Record<string, unknown>>(
+  resource: string,
+  type: 'json',
+  init?: RequestInit
+): Promise<T>;
 
 /**
  * Fetch a statically served resource and parse it as text or url.
- * @param file public resource to fetch
+ * @param resource resource to fetch
  * @param type resource conversion type
  * @param init request options
  * @returns the fetched resource
  */
 export async function fetchResource(
-  file: string,
-  type: 'text' | 'url'
-): Promise<string | undefined>;
+  resource: string,
+  type: 'text' | 'url',
+  init?: RequestInit
+): Promise<string>;
 
-export async function fetchResource(
-  file: string,
+export async function fetchResource<T = Record<string, unknown>>(
+  resource: string,
   type: 'blob' | 'json' | 'text' | 'url',
   init?: RequestInit
-): Promise<Blob | Record<string, unknown> | string | undefined> {
-  const response = await fetch(file, init);
+): Promise<Blob | T | string> {
+  const response = await fetch(resource, init);
 
   if (!response || !response.ok) {
-    console.error(`Failed loading ${file}`);
-    return;
+    throw new Error(
+      `Fetching resource "${resource}" failed` +
+        ` with status "${response.status}: ${response.statusText}"`
+    );
   }
 
   switch (type) {
@@ -51,7 +56,7 @@ export async function fetchResource(
       return (await response.blob()) as Blob;
 
     case 'json':
-      return (await response.json()) as Record<string, unknown>;
+      return (await response.json()) as T;
 
     case 'text':
       return (await response.text()) as string;
@@ -60,6 +65,6 @@ export async function fetchResource(
       return response.url;
 
     default:
-      throw new Error(`Unsupported read method for ${file}`);
+      throw new Error(`Unsupported read method for ${resource}`);
   }
 }


### PR DESCRIPTION
## Summary

This PR adds application state handling to the preload functionality.
- When preloading, display a loading indicator and message.
- If preloading fails at _any_ step, override routes with a custom error message.

## Changes
- Change `fetchResource` so it no longer returns undefined on a not-ok response. Now the helper will always return the appropriate value or throw the relevant error.
- Change `AppLayout` props to extend `FlexProps` from `chakra-ui`. This allows overriding styles for slightly different layout requirements.
- Add application state to reflect the current preloading status: `idle`, `loading`, `failed`.