### PR TITLE
hotfix: optimize accession matching

### DIFF
--- a/src/hooks/match-accesion.ts
+++ b/src/hooks/match-accesion.ts
@@ -1,7 +1,6 @@
 import React from 'react';
 import { dataTable } from '@/store/data-store';
 import { RequireExactlyOne } from 'type-fest';
-
 interface UseMatchAccessionOptions {
   accession?: string;
   maxSize?: number;
@@ -32,9 +31,12 @@ function useMatchAccession(
     return accessionIdsView;
   }, []);
 
-  return options?.accession !== undefined
-    ? matchToStoreAccessions(options.accession)
-    : matchToStoreAccessions;
+  const matches = React.useMemo(() => {
+    if (options?.accession !== undefined)
+      return matchToStoreAccessions(options?.accession);
+  }, [matchToStoreAccessions, options?.accession]);
+
+  return matches ?? matchToStoreAccessions;
 }
 
 export default useMatchAccession;


### PR DESCRIPTION
## Summary

This PR is a small optimization to useMatchAccession so it only searches the database when the accession value changes and is not undefined.