### PR TITLE
feat: Heatmap transpose matrix + filter for genes

### DIFF
--- a/src/components/formik-radio/formik-radio.tsx
+++ b/src/components/formik-radio/formik-radio.tsx
@@ -16,7 +16,7 @@ import {
 
 interface RadioOptions extends RadioProps {
   label: string;
-  disabled: boolean;
+  disabled?: boolean;
 }
 
 interface FormikRadioProps {
@@ -63,6 +63,7 @@ const FormikRadio: React.FC<FormikRadioProps> = ({
         name={field.name}
         value={field.value}
         onChange={handleOnChange}
+        defaultValue={options[0].value}
       >
         <Stack direction={direction}>
           {options.map((option, index) => (

--- a/src/components/formik-replicate/formik-replicate.tsx
+++ b/src/components/formik-replicate/formik-replicate.tsx
@@ -1,0 +1,94 @@
+import { FieldValidator, useField } from 'formik';
+import React from 'react';
+import {
+  Box,
+  FormControl,
+  FormControlProps,
+  FormLabel,
+  FormErrorMessage,
+  Input,
+  InputGroup,
+  InputGroupProps,
+  InputProps,
+  VisuallyHidden,
+} from '@chakra-ui/react';
+import { FocusableElement } from '@chakra-ui/utils';
+import { useMatchReplicate } from '@/hooks';
+
+interface FormikReplicateProps extends InputProps {
+  name: string;
+  label: string;
+  leftChildren?: React.ReactNode;
+  hideLabel?: boolean;
+  controlProps?: FormControlProps;
+  groupProps?: InputGroupProps;
+  initialFocusRef?: React.MutableRefObject<FocusableElement | null>;
+  rightChildren?: React.ReactNode;
+  validate?: FieldValidator;
+}
+
+const FormikReplicate: React.FC<FormikReplicateProps> = ({
+  children,
+  controlProps,
+  groupProps,
+  hideLabel,
+  initialFocusRef,
+  label,
+  leftChildren,
+  name,
+  rightChildren,
+  validate,
+  ...props
+}) => {
+  const [field, meta] = useField({
+    name,
+    validate,
+  });
+
+  const matches = useMatchReplicate({
+    replicate: field.value,
+  });
+
+  return (
+    <FormControl
+      {...controlProps}
+      isInvalid={meta.error !== undefined && meta.touched !== undefined}
+      isRequired={props.isRequired}
+    >
+      {hideLabel ? (
+        <VisuallyHidden>
+          <FormLabel fontWeight="semibold">{label}</FormLabel>
+        </VisuallyHidden>
+      ) : (
+        <FormLabel fontWeight="semibold">{label}</FormLabel>
+      )}
+      <InputGroup as="span" {...groupProps}>
+        {leftChildren}
+        <Input
+          ref={(ref) =>
+            initialFocusRef ? (initialFocusRef.current = ref) : ref
+          }
+          name={field.name}
+          onBlur={field.onBlur}
+          onChange={field.onChange}
+          multiple={field.multiple}
+          value={field.value}
+          {...props}
+          list={`${field.name}-list`}
+        />
+
+        <Box as="datalist" id={`${field.name}-list`}>
+          {matches.map((match) => (
+            <Box as="option" key={match} value={match} />
+          ))}
+        </Box>
+
+        {children}
+        {rightChildren}
+      </InputGroup>
+      <FormErrorMessage as="span">{meta.error}</FormErrorMessage>
+    </FormControl>
+  );
+};
+
+export default FormikReplicate;

--- a/src/components/formik-replicate/index.tsx
+++ b/src/components/formik-replicate/index.tsx
@@ -1,0 +1,3 @@
+import FormikReplicate from './formik-replicate';
+
+export default FormikReplicate;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 import useMatchAccession from './match-accesion';
+import useMatchReplicate from './match-replicate';
 
-export { useMatchAccession };
+export { useMatchAccession, useMatchReplicate };

--- a/src/hooks/match-replicate.ts
+++ b/src/hooks/match-replicate.ts
@@ -1,0 +1,42 @@
+import React from 'react';
+import { dataTable } from '@/store/data-store';
+import { RequireExactlyOne } from 'type-fest';
+interface UseMatchReplicateOptions {
+  replicate?: string;
+  maxSize?: number;
+}
+
+type MatchReplicate = (replicate: string) => string[];
+
+function useMatchReplicate(): MatchReplicate;
+function useMatchReplicate(
+  options: RequireExactlyOne<UseMatchReplicateOptions, 'replicate'>
+): string[];
+function useMatchReplicate(
+  options?: UseMatchReplicateOptions
+): string[] | MatchReplicate {
+  const matchToStoreReplicates = React.useCallback((replicate: string) => {
+    const colNamesSnapshot = dataTable.colNames;
+    const maxSize = 10;
+
+    // Update the search window with the accession matching ids
+    const replicatesView: string[] = [];
+
+    for (let i = 0; i < colNamesSnapshot.length; i++) {
+      if (colNamesSnapshot[i].includes(replicate))
+        replicatesView.push(colNamesSnapshot[i]);
+      if (replicatesView.length >= maxSize) break;
+    }
+
+    return replicatesView;
+  }, []);
+
+  const matches = React.useMemo(() => {
+    if (options?.replicate !== undefined)
+      return matchToStoreReplicates(options?.replicate);
+  }, [matchToStoreReplicates, options?.replicate]);
+
+  return matches ?? matchToStoreReplicates;
+}
+
+export default useMatchReplicate;

--- a/src/pages/plots/components/heatmap-form.tsx
+++ b/src/pages/plots/components/heatmap-form.tsx
@@ -24,6 +24,9 @@ import {
   VisuallyHidden,
 } from '@chakra-ui/react';
 import { FocusableElement } from '@chakra-ui/utils';
+import FormikRadio from '@/components/formik-radio';
+import FormikReplicate from '@/components/formik-replicate';
+import FormikAccession from '@/components/formik-accession';
 
 export type HeatmapFormSubmitHandler = (
   values: HeatmapFormAttributes,
@@ -36,23 +39,32 @@ export interface HeatmapFormProps {
   onSubmit: HeatmapFormSubmitHandler;
 }
 
-interface HeatmapFormAttributes {
+export interface HeatmapFormAttributes {
+  accessions: string[];
+  clusterBy: 'replicates' | 'genes';
   replicates: string[];
-  plotTitle: string;
+  plotTitle?: string;
 }
 
 enum HeatmapFormErrors {
   EMPTY_REPLICATE = 'A replicate field cannot be empty',
+  EMPTY_ACCESSION = 'A gene accession field cannot be empty',
   MIN_OPTIONAL_REPLICATES = 'At least two replicates must be selected',
+  MIN_OPTIONAL_ACCESSIONS = 'At least two genes must be selected',
 }
 
 const HeatmapForm: React.FC<HeatmapFormProps> = (props) => {
   const validateForm = (
     values: HeatmapFormAttributes
   ): FormikErrors<HeatmapFormAttributes> | void => {
-    if (values.replicates.length === 1) {
+    if (values.replicates.length === 1 && values.clusterBy === 'replicates') {
       return {
         replicates: [HeatmapFormErrors.MIN_OPTIONAL_REPLICATES],
+      };
+    }
+    if (values.accessions.length === 1 && values.clusterBy === 'genes') {
+      return {
+        accessions: [HeatmapFormErrors.MIN_OPTIONAL_ACCESSIONS],
       };
     }
   };
@@ -61,9 +73,15 @@ const HeatmapForm: React.FC<HeatmapFormProps> = (props) => {
     if (!value) return HeatmapFormErrors.EMPTY_REPLICATE;
   };
 
+  const validateAccession: FieldValidator = (value: string) => {
+    if (!value) return HeatmapFormErrors.EMPTY_ACCESSION;
+  };
+
   return (
     <Formik<HeatmapFormAttributes>
       initialValues={{
+        accessions: [],
+        clusterBy: 'replicates',
         replicates: [],
         plotTitle: '',
       }}
@@ -100,14 +118,27 @@ const HeatmapForm: React.FC<HeatmapFormProps> = (props) => {
               name="plotTitle"
             />
 
+            <FormikRadio
+              controlProps={{
+                marginTop: '1rem',
+              }}
+              label="Cluster By"
+              name="clusterBy"
+              options={[
+                { label: 'Replicates', value: 'replicates' },
+                { label: 'Genes', value: 'genes' },
+              ]}
+              direction="row"
+            />
+
             <FieldArray name="replicates">
               {(helpers) => (
                 <Box as="fieldset">
                   <VisuallyHidden as="legend">Replicates</VisuallyHidden>
 
                   {formProps.values.replicates.length > 0 &&
-                    formProps.values.replicates.map((accession, index) => (
-                      <FormikField
+                    formProps.values.replicates.map((replicate, index) => (
+                      <FormikReplicate
                         controlProps={{
                           as: 'p',
                           marginTop: '1rem',
@@ -143,7 +174,7 @@ const HeatmapForm: React.FC<HeatmapFormProps> = (props) => {
                               _groupHover={{
                                 color: 'red.600',
                               }}
-                              aria-label={`Remove ${accession}`}
+                              aria-label={`Remove ${replicate}`}
                               color="gray.600"
                               display="flex"
                               justifyContent="center"
@@ -193,7 +224,7 @@ const HeatmapForm: React.FC<HeatmapFormProps> = (props) => {
                         >
                           <Icon as={FaPlus} />
                         </Box>
-                      </FormikField>
+                      </FormikReplicate>
                     ))}
 
                   {/* ADD NEW BUTTON */}
@@ -221,6 +252,133 @@ const HeatmapForm: React.FC<HeatmapFormProps> = (props) => {
                     {formProps.values.replicates.length === 0
                       ? 'Optional: Select Replicates'
                       : 'Add Another Replicate'}
+                  </Button>
+                </Box>
+              )}
+            </FieldArray>
+
+            <FieldArray name="accessions">
+              {(helpers) => (
+                <Box as="fieldset">
+                  <VisuallyHidden as="legend">Genes</VisuallyHidden>
+
+                  {formProps.values.accessions &&
+                    formProps.values.accessions.length > 0 &&
+                    formProps.values.accessions.map((accession, index) => (
+                      <FormikAccession
+                        controlProps={{
+                          as: 'p',
+                          marginTop: '1rem',
+                        }}
+                        groupProps={{
+                          _focusWithin: {
+                            '& > button': {
+                              display: 'inline-flex',
+                            },
+                          },
+                        }}
+                        isRequired
+                        key={index}
+                        label={`Gene Accession ${index + 1}`}
+                        name={`accessions.${index}`}
+                        rightChildren={
+                          // REMOVE BUTTON
+                          <InputRightAddon
+                            _focusWithin={{
+                              backgroundColor: 'white',
+                            }}
+                            _hover={{
+                              backgroundColor: 'white',
+                            }}
+                            as="span"
+                            padding={0}
+                          >
+                            <IconButton
+                              _focus={{
+                                color: 'red.600',
+                                outline: 'none',
+                              }}
+                              _groupHover={{
+                                color: 'red.600',
+                              }}
+                              aria-label={`Remove ${accession}`}
+                              color="gray.600"
+                              display="flex"
+                              justifyContent="center"
+                              icon={<FaTrash />}
+                              onClick={() => helpers.remove(index)}
+                              size="md"
+                              variant="unstyled"
+                            />
+                          </InputRightAddon>
+                        }
+                        validate={validateAccession}
+                      >
+                        {/* INSERT BUTTON */}
+                        <Box
+                          display="none"
+                          color="gray.500"
+                          _groupFocus={{
+                            display: 'inline-flex',
+                          }}
+                          _groupHover={{
+                            display: 'inline-flex',
+                          }}
+                          _focus={{
+                            backgroundColor: 'orange.600',
+                            color: 'white',
+                            outline: 'none',
+                          }}
+                          _hover={{
+                            backgroundColor: 'orange.600',
+                            color: 'white',
+                          }}
+                          alignItems="center"
+                          as="button"
+                          aria-label={`Insert new below`}
+                          backgroundColor="white"
+                          height="1rem"
+                          justifyContent="center"
+                          left="43%"
+                          padding=".75rem"
+                          position="absolute"
+                          rounded="full"
+                          top="28px"
+                          type="button"
+                          width="1rem"
+                          zIndex="popover"
+                          onClick={() => helpers.insert(index + 1, '')}
+                        >
+                          <Icon as={FaPlus} />
+                        </Box>
+                      </FormikAccession>
+                    ))}
+
+                  {/* ADD NEW BUTTON */}
+                  <Button
+                    _focus={{
+                      outline: 'none',
+                      backgroundColor: 'orange.100',
+                    }}
+                    _hover={{
+                      backgroundColor: 'orange.100',
+                    }}
+                    colorScheme="orange"
+                    marginTop="1rem"
+                    type="button"
+                    onClick={() => {
+                      if (formProps.values.accessions.length === 0) {
+                        helpers.push('');
+                        helpers.push('');
+                      } else {
+                        helpers.push('');
+                      }
+                    }}
+                    variant="ghost"
+                  >
+                    {formProps.values.accessions.length === 0
+                      ? 'Optional: Select Genes'
+                      : 'Add Another Genes'}
                   </Button>
                 </Box>
               )}

--- a/src/pages/plots/plots-home.tsx
+++ b/src/pages/plots/plots-home.tsx
@@ -151,11 +151,20 @@ const PlotsHome: React.FC = () => {
     onClose: onHeatmapFormClose,
   } = useDisclosure();
 
-  const onHeatmapFormSubmit: HeatmapFormSubmitHandler = (values, actions) => {
+  const onHeatmapFormSubmit: HeatmapFormSubmitHandler = (
+    { plotTitle, accessions, clusterBy, replicates },
+    actions
+  ) => {
     actions.setSubmitting(false);
     onHeatmapFormClose();
     setTimeout(
-      () => plotStore.addHeatmapPlot(values.plotTitle, values.replicates),
+      () =>
+        plotStore.addHeatmapPlot({
+          plotTitle,
+          accessions,
+          clusterBy,
+          replicates,
+        }),
       10
     );
   };

--- a/src/pages/plots/plots-home.tsx
+++ b/src/pages/plots/plots-home.tsx
@@ -246,7 +246,7 @@ const PlotsHome: React.FC = () => {
         />
 
         <SidebarButton
-          text="Heatmap"
+          text="Cluster Heatmap"
           icon={FaBurn}
           onClick={onHeatmapFormOpen}
           disabled={!dataAvailable}

--- a/src/types/plots.ts
+++ b/src/types/plots.ts
@@ -1,3 +1,4 @@
+import { DataRows } from '@/store/dataframe';
 import { Layout, PlotData } from 'plotly.js';
 
 export type PlotType = 'heatmap' | 'pca' | 'plotly' | 'image';
@@ -43,6 +44,13 @@ export interface HeatmapBins {
 export interface HeatmapBin {
   bin: string;
   count: number;
+}
+
+export interface CreateHeatmapArgs {
+  dataRows: DataRows;
+  srcReplicateNames: string[];
+  srcAccessionIds: string[];
+  transpose: boolean;
 }
 
 //#endregion

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -10,7 +10,7 @@ import { isNumeric } from '@/utils/validation';
 export function toArrayOfRows(
   rows: DataRows,
   filterByColumn: string[] = [],
-  filterByRow: string[]
+  filterByRow: string[] = []
 ): number[][] {
   /**
    * Reduce the dataframe header to a subset of its column names.
@@ -78,7 +78,7 @@ export function toArrayOfRows(
 export function toArrayOfColumns(
   rows: DataRows,
   filterByColumn: string[] = [],
-  filterByRow: string[]
+  filterByRow: string[] = []
 ): number[][] {
   const arrayOfRows = toArrayOfRows(rows, filterByColumn, filterByRow);
   const arrayOfCols = arrayOfRows[0].map((_, colIndex) =>

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -9,7 +9,8 @@ import { isNumeric } from '@/utils/validation';
  */
 export function toArrayOfRows(
   rows: DataRows,
-  filterByColumn: string[] = []
+  filterByColumn: string[] = [],
+  filterByRow: string[]
 ): number[][] {
   /**
    * Reduce the dataframe header to a subset of its column names.
@@ -59,7 +60,11 @@ export function toArrayOfRows(
     return counts.map(castToNumber);
   };
 
-  const array2d = Object.entries(rows).map(toCountsArray);
+  const filteredRowEntries: [string, string[]][] = filterByRow.map((key) => [
+    key,
+    rows[key],
+  ]);
+  const array2d = filteredRowEntries.map(toCountsArray);
 
   return array2d;
 }
@@ -72,9 +77,10 @@ export function toArrayOfRows(
  */
 export function toArrayOfColumns(
   rows: DataRows,
-  filterByColumn: string[] = []
+  filterByColumn: string[] = [],
+  filterByRow: string[]
 ): number[][] {
-  const arrayOfRows = toArrayOfRows(rows, filterByColumn);
+  const arrayOfRows = toArrayOfRows(rows, filterByColumn, filterByRow);
   const arrayOfCols = arrayOfRows[0].map((_, colIndex) =>
     arrayOfRows.map((row) => row[colIndex])
   );

--- a/src/workers/heatmap.ts
+++ b/src/workers/heatmap.ts
@@ -1,10 +1,13 @@
-import { DataRows } from '@/store/dataframe';
+import { CreateHeatmapArgs } from '@/types/plots';
 import { createHeatmapPlot } from '@/utils/plots/heatmap';
 
-onmessage = function (
-  e: MessageEvent<{ dataRows: DataRows; srcReplicateNames: string[] }>
-) {
-  const { dataRows, srcReplicateNames } = e.data;
-  const workerResult = createHeatmapPlot(dataRows, srcReplicateNames);
+onmessage = function (e: MessageEvent<CreateHeatmapArgs>) {
+  const { dataRows, srcReplicateNames, srcAccessionIds, transpose } = e.data;
+  const workerResult = createHeatmapPlot(
+    dataRows,
+    srcReplicateNames,
+    srcAccessionIds,
+    transpose
+  );
   postMessage(workerResult, undefined as unknown as string);
 };


### PR DESCRIPTION
## Summary

This PR enables support to transpose the input matrix for the Heatmap plot. This enables us to cluster replicates as well as genes by their measure of likeness.

Furthermore added support to use only a subset of genes for the Heatmap plot.

## Changes
- refactor: formik-radio optional disable prop
- feat: match-replicate hook
- feat: formik replicate component
- feat: heatmap add optional gene filter and transpose option
- refactor: plot-sidebar rename heatmap -> cluster heatmap
- fix: add default empty array for row-filter 