### PR TITLE
feat: pca transpose matrix + filter genes/replicates

### DIFF
--- a/src/pages/plots/components/pca-form.tsx
+++ b/src/pages/plots/components/pca-form.tsx
@@ -1,8 +1,27 @@
-import { Formik, Form, FormikHelpers } from 'formik';
+import {
+  Formik,
+  Form,
+  FormikHelpers,
+  FieldValidator,
+  FormikErrors,
+  FieldArray,
+} from 'formik';
 import React from 'react';
 import FormikField from '@/components/formik-field';
-import { Box, Button, Flex } from '@chakra-ui/react';
+import {
+  Box,
+  Button,
+  Flex,
+  Icon,
+  IconButton,
+  InputRightAddon,
+  VisuallyHidden,
+} from '@chakra-ui/react';
 import { FocusableElement } from '@chakra-ui/utils';
+import FormikRadio from '@/components/formik-radio';
+import FormikReplicate from '@/components/formik-replicate';
+import { FaTrash, FaPlus } from 'react-icons/fa';
+import FormikAccession from '@/components/formik-accession';
 
 export type PCAFormSubmitHandler = (
   values: PCAFormAttributes,
@@ -15,17 +34,57 @@ export interface PCAFormProps {
   onSubmit: PCAFormSubmitHandler;
 }
 
-interface PCAFormAttributes {
-  plotTitle: string;
+export interface PCAFormAttributes {
+  accessions: string[];
+  calculateFor: 'replicates' | 'genes';
+  replicates: string[];
+  plotTitle?: string;
+}
+
+enum PCAFormErrors {
+  EMPTY_REPLICATE = 'A replicate field cannot be empty',
+  EMPTY_ACCESSION = 'A gene accession field cannot be empty',
+  MIN_OPTIONAL_REPLICATES = 'At least two replicates must be selected',
+  MIN_OPTIONAL_ACCESSIONS = 'At least two genes must be selected',
 }
 
 const PCAForm: React.FC<PCAFormProps> = (props) => {
+  const validateForm = (
+    values: PCAFormAttributes
+  ): FormikErrors<PCAFormAttributes> | void => {
+    if (
+      values.replicates.length === 1 &&
+      values.calculateFor === 'replicates'
+    ) {
+      return {
+        replicates: [PCAFormErrors.MIN_OPTIONAL_REPLICATES],
+      };
+    }
+    if (values.accessions.length === 1 && values.calculateFor === 'genes') {
+      return {
+        accessions: [PCAFormErrors.MIN_OPTIONAL_ACCESSIONS],
+      };
+    }
+  };
+
+  const validateReplicate: FieldValidator = (value: string) => {
+    if (!value) return PCAFormErrors.EMPTY_REPLICATE;
+  };
+
+  const validateAccession: FieldValidator = (value: string) => {
+    if (!value) return PCAFormErrors.EMPTY_ACCESSION;
+  };
+
   return (
     <Formik<PCAFormAttributes>
       initialValues={{
+        accessions: [],
+        calculateFor: 'replicates',
+        replicates: [],
         plotTitle: '',
       }}
       validateOnBlur={false}
+      validate={validateForm}
       onSubmit={props.onSubmit}
     >
       {(formProps) => (
@@ -39,6 +98,272 @@ const PCAForm: React.FC<PCAFormProps> = (props) => {
             label="Plot Title"
             name="plotTitle"
           />
+
+          <FormikRadio
+            controlProps={{
+              marginTop: '1rem',
+            }}
+            label="Calculate For"
+            name="calculateFor"
+            options={[
+              { label: 'Replicates', value: 'replicates' },
+              { label: 'Genes', value: 'genes' },
+            ]}
+            direction="row"
+          />
+
+          <FieldArray name="replicates">
+            {(helpers) => (
+              <Box as="fieldset">
+                <VisuallyHidden as="legend">Replicates</VisuallyHidden>
+
+                {formProps.values.replicates.length > 0 &&
+                  formProps.values.replicates.map((replicate, index) => (
+                    <FormikReplicate
+                      controlProps={{
+                        as: 'p',
+                        marginTop: '1rem',
+                      }}
+                      groupProps={{
+                        _focusWithin: {
+                          '& > button': {
+                            display: 'inline-flex',
+                          },
+                        },
+                      }}
+                      isRequired
+                      key={index}
+                      label={`Replicate ${index + 1}`}
+                      name={`replicates.${index}`}
+                      rightChildren={
+                        // REMOVE BUTTON
+                        <InputRightAddon
+                          _focusWithin={{
+                            backgroundColor: 'white',
+                          }}
+                          _hover={{
+                            backgroundColor: 'white',
+                          }}
+                          as="span"
+                          padding={0}
+                        >
+                          <IconButton
+                            _focus={{
+                              color: 'red.600',
+                              outline: 'none',
+                            }}
+                            _groupHover={{
+                              color: 'red.600',
+                            }}
+                            aria-label={`Remove ${replicate}`}
+                            color="gray.600"
+                            display="flex"
+                            justifyContent="center"
+                            icon={<FaTrash />}
+                            onClick={() => helpers.remove(index)}
+                            size="md"
+                            variant="unstyled"
+                          />
+                        </InputRightAddon>
+                      }
+                      validate={validateReplicate}
+                    >
+                      {/* INSERT BUTTON */}
+                      <Box
+                        display="none"
+                        color="gray.500"
+                        _groupFocus={{
+                          display: 'inline-flex',
+                        }}
+                        _groupHover={{
+                          display: 'inline-flex',
+                        }}
+                        _focus={{
+                          backgroundColor: 'orange.600',
+                          color: 'white',
+                          outline: 'none',
+                        }}
+                        _hover={{
+                          backgroundColor: 'orange.600',
+                          color: 'white',
+                        }}
+                        alignItems="center"
+                        as="button"
+                        aria-label={`Insert new below`}
+                        backgroundColor="white"
+                        height="1rem"
+                        justifyContent="center"
+                        left="43%"
+                        padding=".75rem"
+                        position="absolute"
+                        rounded="full"
+                        top="28px"
+                        type="button"
+                        width="1rem"
+                        zIndex="popover"
+                        onClick={() => helpers.insert(index + 1, '')}
+                      >
+                        <Icon as={FaPlus} />
+                      </Box>
+                    </FormikReplicate>
+                  ))}
+
+                {/* ADD NEW BUTTON */}
+                <Button
+                  _focus={{
+                    outline: 'none',
+                    backgroundColor: 'orange.100',
+                  }}
+                  _hover={{
+                    backgroundColor: 'orange.100',
+                  }}
+                  colorScheme="orange"
+                  marginTop="1rem"
+                  type="button"
+                  onClick={() => {
+                    if (formProps.values.replicates.length === 0) {
+                      helpers.push('');
+                      helpers.push('');
+                    } else {
+                      helpers.push('');
+                    }
+                  }}
+                  variant="ghost"
+                >
+                  {formProps.values.replicates.length === 0
+                    ? 'Optional: Select Replicates'
+                    : 'Add Another Replicate'}
+                </Button>
+              </Box>
+            )}
+          </FieldArray>
+
+          <FieldArray name="accessions">
+            {(helpers) => (
+              <Box as="fieldset">
+                <VisuallyHidden as="legend">Genes</VisuallyHidden>
+
+                {formProps.values.accessions &&
+                  formProps.values.accessions.length > 0 &&
+                  formProps.values.accessions.map((accession, index) => (
+                    <FormikAccession
+                      controlProps={{
+                        as: 'p',
+                        marginTop: '1rem',
+                      }}
+                      groupProps={{
+                        _focusWithin: {
+                          '& > button': {
+                            display: 'inline-flex',
+                          },
+                        },
+                      }}
+                      isRequired
+                      key={index}
+                      label={`Gene Accession ${index + 1}`}
+                      name={`accessions.${index}`}
+                      rightChildren={
+                        // REMOVE BUTTON
+                        <InputRightAddon
+                          _focusWithin={{
+                            backgroundColor: 'white',
+                          }}
+                          _hover={{
+                            backgroundColor: 'white',
+                          }}
+                          as="span"
+                          padding={0}
+                        >
+                          <IconButton
+                            _focus={{
+                              color: 'red.600',
+                              outline: 'none',
+                            }}
+                            _groupHover={{
+                              color: 'red.600',
+                            }}
+                            aria-label={`Remove ${accession}`}
+                            color="gray.600"
+                            display="flex"
+                            justifyContent="center"
+                            icon={<FaTrash />}
+                            onClick={() => helpers.remove(index)}
+                            size="md"
+                            variant="unstyled"
+                          />
+                        </InputRightAddon>
+                      }
+                      validate={validateAccession}
+                    >
+                      {/* INSERT BUTTON */}
+                      <Box
+                        display="none"
+                        color="gray.500"
+                        _groupFocus={{
+                          display: 'inline-flex',
+                        }}
+                        _groupHover={{
+                          display: 'inline-flex',
+                        }}
+                        _focus={{
+                          backgroundColor: 'orange.600',
+                          color: 'white',
+                          outline: 'none',
+                        }}
+                        _hover={{
+                          backgroundColor: 'orange.600',
+                          color: 'white',
+                        }}
+                        alignItems="center"
+                        as="button"
+                        aria-label={`Insert new below`}
+                        backgroundColor="white"
+                        height="1rem"
+                        justifyContent="center"
+                        left="43%"
+                        padding=".75rem"
+                        position="absolute"
+                        rounded="full"
+                        top="28px"
+                        type="button"
+                        width="1rem"
+                        zIndex="popover"
+                        onClick={() => helpers.insert(index + 1, '')}
+                      >
+                        <Icon as={FaPlus} />
+                      </Box>
+                    </FormikAccession>
+                  ))}
+
+                {/* ADD NEW BUTTON */}
+                <Button
+                  _focus={{
+                    outline: 'none',
+                    backgroundColor: 'orange.100',
+                  }}
+                  _hover={{
+                    backgroundColor: 'orange.100',
+                  }}
+                  colorScheme="orange"
+                  marginTop="1rem"
+                  type="button"
+                  onClick={() => {
+                    if (formProps.values.accessions.length === 0) {
+                      helpers.push('');
+                      helpers.push('');
+                    } else {
+                      helpers.push('');
+                    }
+                  }}
+                  variant="ghost"
+                >
+                  {formProps.values.accessions.length === 0
+                    ? 'Optional: Select Genes'
+                    : 'Add Another Genes'}
+                </Button>
+              </Box>
+            )}
+          </FieldArray>
 
           <Flex as="p" paddingY={6} justifyContent="flex-end">
             <Button onClick={props.onCancel} colorScheme="red" variant="ghost">

--- a/src/pages/plots/plots-home.tsx
+++ b/src/pages/plots/plots-home.tsx
@@ -151,22 +151,10 @@ const PlotsHome: React.FC = () => {
     onClose: onHeatmapFormClose,
   } = useDisclosure();
 
-  const onHeatmapFormSubmit: HeatmapFormSubmitHandler = (
-    { plotTitle, accessions, clusterBy, replicates },
-    actions
-  ) => {
+  const onHeatmapFormSubmit: HeatmapFormSubmitHandler = (values, actions) => {
     actions.setSubmitting(false);
     onHeatmapFormClose();
-    setTimeout(
-      () =>
-        plotStore.addHeatmapPlot({
-          plotTitle,
-          accessions,
-          clusterBy,
-          replicates,
-        }),
-      10
-    );
+    setTimeout(() => plotStore.addHeatmapPlot(values), 10);
   };
 
   /* PCA PLOT */
@@ -182,7 +170,7 @@ const PlotsHome: React.FC = () => {
   const onPCAFormSubmit: PCAFormSubmitHandler = (values, actions) => {
     actions.setSubmitting(false);
     onPCAFormClose();
-    setTimeout(() => plotStore.addPCAPlot(values.plotTitle), 10);
+    setTimeout(() => plotStore.addPCAPlot(values), 10);
   };
 
   /* IMAGE PLOT */

--- a/src/types/plots.ts
+++ b/src/types/plots.ts
@@ -76,6 +76,14 @@ export interface GxpPCA extends GxpPlot {
   layout: Partial<Layout>;
 }
 
+export interface CreatePCAargs {
+  dataRows: DataRows;
+  srcReplicateNames: string[];
+  srcAccessionIds: string[];
+  transpose: boolean;
+  plotTitle?: string;
+  multiHeaderSep: string;
+}
 //#endregion
 
 //#region Images

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,7 +1,7 @@
 import iwanthue from 'iwanthue';
 
 export function setToColors(set: Set<string>): Record<string, string> {
-  const colors = iwanthue(set.size);
+  const colors = getColors(set.size);
   const values = Array.from(set.values());
   const valueColorZip = values.map((value, index) => [value, colors[index]]);
   const colorMap: Record<string, string> = Object.fromEntries(valueColorZip);
@@ -36,5 +36,15 @@ export function getSubheaderColors(
   // Assign subheader colors
   const colors = subHeaders.map((head) => colorsMap[head]);
 
+  return colors;
+}
+
+/**
+ * Get an array of n colors
+ * @param n number of colors
+ * @returns array of n distinct colors
+ */
+export function getColors(n: number): string[] {
+  const colors = n === 1 ? [iwanthue(2)[0]] : iwanthue(n);
   return colors;
 }

--- a/src/workers/pca.ts
+++ b/src/workers/pca.ts
@@ -1,20 +1,22 @@
-import { DataRows } from '@/store/dataframe';
-import pcaData from '@/utils/plots/pca';
+import { CreatePCAargs } from '@/types/plots';
+import { createPCAplot } from '@/utils/plots/pca';
 
-onmessage = function (
-  e: MessageEvent<{
-    dataRows: DataRows;
-    srcReplicateNames: string[];
-    multiHeaderSep: string;
-    plotTitle?: string;
-  }>
-) {
-  const { dataRows, srcReplicateNames, multiHeaderSep, plotTitle } = e.data;
-  const workerResult = pcaData(
+onmessage = function (e: MessageEvent<CreatePCAargs>) {
+  const {
     dataRows,
     srcReplicateNames,
+    srcAccessionIds,
     multiHeaderSep,
-    plotTitle
+    transpose,
+    plotTitle,
+  } = e.data;
+  const workerResult = createPCAplot(
+    dataRows,
+    srcReplicateNames,
+    srcAccessionIds,
+    multiHeaderSep,
+    plotTitle,
+    transpose
   );
   postMessage(workerResult, undefined as unknown as string);
 };


### PR DESCRIPTION
## Summary

This PR enables support to transpose the input matrix for the PCA plot. This enables us to analyize replicates as well as genes.

Furthermore added support to use only a subset of genes and/or replicates for the PCA plot.

## Changes
- feat: pca add optional gene/replicate filter and transpose option
- feat: add generic getColors method