### PR TITLE
fix: loading buffer for exporting GXP database

### DIFF
--- a/src/pages/data/data-files.tsx
+++ b/src/pages/data/data-files.tsx
@@ -374,7 +374,6 @@ const DataFiles: React.FC = () => {
 
       if (values.exportPlots) {
         const plotsSrc = JSON.stringify(plotStore.plotNamesForExport());
-        console.log({ plotsSrc });
         if (plotsSrc) {
           zip.file('plots.json', plotsSrc);
           zip.folder('plots');
@@ -398,15 +397,11 @@ const DataFiles: React.FC = () => {
         }
       }
 
-      zip
-        .generateAsync({ type: 'blob' })
-        .then((zipFile) => {
-          saveAs(zipFile, values.fileName + '.zip');
-        })
-        .finally(() => {
-          actions.setSubmitting(false);
-          onGXPExportClose();
-        });
+      const zipFile = await zip.generateAsync({ type: 'blob' });
+      saveAs(zipFile, values.fileName + '.zip');
+
+      actions.setSubmitting(false);
+      onGXPExportClose();
     } catch (error) {
       actions.setSubmitting(false);
       console.error(error);


### PR DESCRIPTION
## Summary
This PR implements the loading buffer when exporting a GXP database

## Changes
fix: use await syntax for export. enables the form to render the loading buffer and wait for the export to finish.

## Notes
Since exporting (the same goes for importing) are `async` they are actually non-blocking. You are able to leave the export/import form. If you do react will give a warning of a non-op, since it tries to set the loading state to false for a Form that is not there anymore.