### PR TITLE
fix: typos, labels

### DIFF
--- a/src/pages/plots/components/bars-form.tsx
+++ b/src/pages/plots/components/bars-form.tsx
@@ -120,7 +120,7 @@ const BarsForm: React.FC<BarsFormProps> = (props) => {
                       }}
                       isRequired
                       key={index}
-                      label={`Gene Accession ${index + 1}`}
+                      label={`Gene Identifier ${index + 1}`}
                       name={`accessions.${index}`}
                       rightChildren={
                         formProps.values.accessions.length > 1 && (

--- a/src/pages/plots/components/heatmap-form.tsx
+++ b/src/pages/plots/components/heatmap-form.tsx
@@ -334,7 +334,7 @@ const HeatmapForm: React.FC<HeatmapFormProps> = (props) => {
                         }}
                         isRequired
                         key={index}
-                        label={`Gene Accession ${index + 1}`}
+                        label={`Gene Identifier ${index + 1}`}
                         name={`accessions.${index}`}
                         rightChildren={
                           // REMOVE BUTTON

--- a/src/pages/plots/components/individual-lines-form.tsx
+++ b/src/pages/plots/components/individual-lines-form.tsx
@@ -120,7 +120,7 @@ const IndividualLinesForm: React.FC<IndividualLinesFormProps> = (props) => {
                       }}
                       isRequired
                       key={index}
-                      label={`Gene Accession ${index + 1}`}
+                      label={`Gene Identifier ${index + 1}`}
                       name={`accessions.${index}`}
                       rightChildren={
                         formProps.values.accessions.length > 1 && (

--- a/src/pages/plots/components/pca-form.tsx
+++ b/src/pages/plots/components/pca-form.tsx
@@ -298,7 +298,7 @@ const PCAForm: React.FC<PCAFormProps> = (props) => {
                       }}
                       isRequired
                       key={index}
-                      label={`Gene Accession ${index + 1}`}
+                      label={`Gene Identifier ${index + 1}`}
                       name={`accessions.${index}`}
                       rightChildren={
                         // REMOVE BUTTON

--- a/src/pages/plots/components/stacked-lines-form.tsx
+++ b/src/pages/plots/components/stacked-lines-form.tsx
@@ -112,7 +112,7 @@ const StackedLinesForm: React.FC<StackedLinesFormProps> = (props) => {
             options={[
               { label: 'Group', value: 'group', disabled: false },
               {
-                label: 'Accession',
+                label: 'Gene',
                 value: 'accession',
                 disabled: formProps.values.accessions.length === 1,
               },
@@ -141,7 +141,7 @@ const StackedLinesForm: React.FC<StackedLinesFormProps> = (props) => {
                       }}
                       isRequired
                       key={index}
-                      label={`Gene Accession ${index + 1}`}
+                      label={`Gene Identifier ${index + 1}`}
                       name={`accessions.${index}`}
                       rightChildren={
                         formProps.values.accessions.length > 1 && (

--- a/src/pages/plots/plots-home.tsx
+++ b/src/pages/plots/plots-home.tsx
@@ -489,7 +489,7 @@ const PlotsHome: React.FC = () => {
         isOpen={isBarsFormOpen}
         onClose={onBarsFormClose}
         size="xl"
-        title="Bars Plot"
+        title="Bar Plot"
         scrollBehavior="outside"
       >
         <BarsForm

--- a/src/pages/tools/tools-home.tsx
+++ b/src/pages/tools/tools-home.tsx
@@ -20,7 +20,7 @@ const ToolsPage: React.FC = () => {
         icon={FaDna}
         label="Gene Browser"
         text={`
-          The gene browser provides is a tools to search and inspect the
+          The gene browser provides an interface to search and inspect the
           individual gene information stored in the replicates database.
           All searches are privately kept within your browser and will not be
           sent anywhere.


### PR DESCRIPTION
- bars plot -> bar plot
- is a tool” or “provides tools to”. GeneBrowser
- accession -> identifier in plot forms