### PR TITLE
Mapman plot refactor

### DIFF
--- a/src/pages/plots/components/mapman-plot.tsx
+++ b/src/pages/plots/components/mapman-plot.tsx
@@ -3,13 +3,7 @@ import * as d3 from 'd3';
 
 import PlotContainer from './plot-container';
 import { GxpMapMan } from '@/types/plots';
-import { dataTable, infoTable } from '@/store/data-store';
-import {
-  getBlockformat,
-  getCoordinates,
-  getMapManBins,
-  parseXmlData,
-} from '@/utils/plots/mapman-xml-domparser';
+import { parseXmlData } from '@/utils/plots/mapman-xml-domparser';
 
 import { interpolateRdBu } from 'd3-scale-chromatic';
 import { scaleSequential } from 'd3-scale';
@@ -28,13 +22,17 @@ import {
   Td,
   TableCaption,
 } from '@chakra-ui/react';
+import { GxpMapManRect, GxpMapManStats } from '@/utils/plots/mapman';
 
 const gradient0 = '#f33d15';
 const gradient1 = '#b4fbde';
 
 const INITIALSIZE = 5;
 
-type MapManPlotProps = GxpMapMan;
+interface MapManPlotProps extends GxpMapMan {
+  rects: GxpMapManRect[];
+  stats: GxpMapManStats;
+}
 
 const MapManPlot: React.FC<MapManPlotProps> = (props) => {
   const ref = useRef(null);
@@ -43,30 +41,42 @@ const MapManPlot: React.FC<MapManPlotProps> = (props) => {
 
   const [rectSize, setRectSize] = useState(5);
 
-  const [group, sample] = props.sample
-    ? props.sample.split(dataTable.config.multiHeader)
-    : [undefined, undefined];
-
   const [plotStatus, setPlotStatus] = useState<'loading' | 'idle'>('loading');
 
-  const [stats, setStats] = useState({
-    minValue: 0,
-    quartile1: 0,
-    median: 0,
-    mean: 0,
-    quartile3: 0,
-    maxValue: 0,
-  });
-
-  console.log({ stats });
-
   useLayoutEffect(() => {
-    const valuesAsArray: number[] = [];
+    // color
+    let colorX = 0;
+    let colorY = 0;
+    switch (props.colorScale) {
+      case 'diverging_-xx':
+        colorX = -(props.colorScaleValueX as number);
+        colorY = props.colorScaleValueX as number;
+        break;
+      case 'continuous_0q3':
+        colorX = 0;
+        colorY = props.stats.q3;
+        break;
+      case 'continuous_q1q3':
+        colorX = props.stats.q1;
+        colorY = props.stats.q3;
+        break;
+      case 'continuous_xy':
+        colorX = props.colorScaleValueX as number;
+        colorY = props.colorScaleValueY as number;
+        break;
+      default:
+        break;
+    }
 
-    const rectValues =
-      props.valuesFrom === 'expressionValue' && group && sample
-        ? dataTable.getMapManMeanValues(group, sample)
-        : infoTable.getColumn(props.valuesFrom);
+    const colorScaleValues = [colorX, colorY];
+
+    const colorScale =
+      props.colorScale === 'diverging_-xx'
+        ? scaleSequential(colorScaleValues.reverse(), interpolateRdBu)
+        : scaleLinear<string>({
+            range: [gradient1, gradient0],
+            domain: colorScaleValues,
+          });
 
     let svgWidth = '1024';
     let svgHeight = '800';
@@ -89,142 +99,34 @@ const MapManPlot: React.FC<MapManPlotProps> = (props) => {
         .attr('viewBox', `0 0 ${svgWidth} ${svgHeight}`)
         .classed('main-svg', true);
       (svg.node() as any).append(data.documentElement);
+      const svgViz = d3
+        .select(svgRef.current)
+        .append('g')
+        .attr('id', 'viz-layer');
 
-      parseXmlData(`mapman-templates/${props.template}.xml`).then(
-        (xmlDocument) => {
-          const svgViz = d3
-            .select(svgRef.current)
-            .append('g')
-            .attr('id', 'viz-layer');
+      const rects = svgViz
+        .selectAll('rect')
+        .data(props.rects)
+        .enter()
+        .append('rect');
 
-          const dataAreas = xmlDocument.querySelectorAll('DataArea');
-
-          dataAreas.forEach((dataArea: Element) => {
-            const { x, y } = getCoordinates(dataArea);
-            const { bformat, fnumber } = getBlockformat(dataArea);
-            const bins = getMapManBins(dataArea);
-
-            const geneIds = infoTable.getGenesForMapManBin(
-              props.infoTableColumn,
-              props.infoTableColumnSep,
-              bins[0].id,
-              bins[0].recursive
-            );
-
-            let xOffset = 0;
-            let yOffset = 0;
-
-            geneIds.forEach((geneId) => {
-              const rectValue = parseFloat(rectValues[geneId] as string);
-              valuesAsArray.push(rectValue);
-
-              const xValue =
-                bformat === 'x'
-                  ? x + (xOffset % fnumber) * INITIALSIZE
-                  : x + xOffset * INITIALSIZE;
-              const yValue =
-                bformat === 'y'
-                  ? y + (yOffset % fnumber) * INITIALSIZE
-                  : y + yOffset * INITIALSIZE;
-
-              svgViz
-                .append('rect')
-                .attr('x', xValue)
-                .attr('y', yValue)
-                .attr('height', INITIALSIZE)
-                .attr('width', INITIALSIZE)
-                .attr('xOffset', bformat === 'x' ? xOffset % fnumber : xOffset)
-                .attr('yOffset', bformat === 'y' ? yOffset % fnumber : yOffset)
-                .attr('value', rectValue)
-                .style('stroke', 'lightgray')
-                .style('stroke-width', INITIALSIZE * 0.1)
-                .append('title')
-                .text(
-                  `Gene-ID: ${geneId}\nMapMan_BINCODE: ${bins[0].id}\n${props.valuesFrom}: ${rectValue}`
-                );
-
-              bformat === 'x' ? xOffset++ : yOffset++;
-              if (bformat === 'x' && xOffset != 0 && xOffset % fnumber === 0) {
-                yOffset++;
-              } else if (
-                bformat === 'y' &&
-                yOffset != 0 &&
-                yOffset % fnumber === 0
-              ) {
-                xOffset++;
-              }
-            });
-          });
-
-          const minValue = d3.min(valuesAsArray) ?? 0;
-          const quartile1 = d3.quantile(valuesAsArray, 0.25) ?? 0;
-          const median = d3.median(valuesAsArray) ?? 0;
-          const mean = d3.mean(valuesAsArray) ?? 0;
-          const quartile3 = d3.quantile(valuesAsArray, 0.75) ?? 0;
-          const maxValue = d3.max(valuesAsArray) ?? 0;
-
-          setStats({
-            minValue,
-            quartile1,
-            median,
-            mean,
-            quartile3,
-            maxValue,
-          });
-          console.log({
-            minValue,
-            quartile1,
-            median,
-            mean,
-            quartile3,
-            maxValue,
-          });
-
-          let colorX = 0;
-          let colorY = 0;
-          switch (props.colorScale) {
-            case 'diverging_-xx':
-              colorX = -(props.colorScaleValueX as number);
-              colorY = props.colorScaleValueX as number;
-              break;
-            case 'continuous_0q3':
-              colorX = 0;
-              colorY = quartile3;
-              break;
-            case 'continuous_q1q3':
-              colorX = quartile1;
-              colorY = quartile3;
-              break;
-            case 'continuous_xy':
-              colorX = props.colorScaleValueX as number;
-              colorY = props.colorScaleValueY as number;
-              break;
-            default:
-              break;
-          }
-
-          const colorScaleValues = [colorX, colorY];
-          console.log({ colorX, colorY, colorScale: props.colorScale });
-
-          const colorScale =
-            props.colorScale === 'diverging_-xx'
-              ? scaleSequential(colorScaleValues.reverse(), interpolateRdBu)
-              : scaleLinear<string>({
-                  range: [gradient1, gradient0],
-                  domain: colorScaleValues,
-                });
-
-          const rects = d3
-            .select(svgRef.current)
-            .select('#viz-layer')
-            .selectAll('rect');
-          rects.style('fill', function () {
-            const value = parseFloat(d3.select(this).attr('value'));
-            return colorScale(value);
-          });
-          setPlotStatus('idle');
-        }
-      );
+      rects
+        .attr('x', ({ x }) => x)
+        .attr('y', ({ y }) => y)
+        .attr('height', INITIALSIZE)
+        .attr('width', INITIALSIZE)
+        .attr('xOffset', ({ xOffset }) => xOffset)
+        .attr('yOffset', ({ yOffset }) => yOffset)
+        .attr('value', ({ value }) => value)
+        .style('stroke', 'lightgray')
+        .style('stroke-width', INITIALSIZE * 0.1)
+        .style('fill', ({ value }) => colorScale(value))
+        .append('title')
+        .text(
+          ({ geneId, bin, value }) =>
+            `Gene-ID: ${geneId}\nMapMan_BINCODE: ${bin}\n${props.valuesFrom}: ${value}`
+        );
+      setPlotStatus('idle');
     });
   }, []);
 
@@ -289,37 +191,29 @@ const MapManPlot: React.FC<MapManPlotProps> = (props) => {
           <Table variant="simple" size="sm" width="25rem">
             <TableCaption>{`Distribution of ${props.valuesFrom}`}</TableCaption>
             <Thead>
-              <Th isNumeric>Min</Th>
-              <Th isNumeric>Q1</Th>
-              <Th isNumeric>Median</Th>
-              <Th isNumeric>Mean</Th>
-              <Th isNumeric>Q3</Th>
-              <Th isNumeric>Max</Th>
+              <Tr>
+                <Th isNumeric>Min</Th>
+                <Th isNumeric>Q1</Th>
+                <Th isNumeric>Median</Th>
+                <Th isNumeric>Mean</Th>
+                <Th isNumeric>Q3</Th>
+                <Th isNumeric>Max</Th>
+              </Tr>
             </Thead>
             <Tbody>
               <Tr>
-                <Td isNumeric>{stats.minValue.toFixed(2)}</Td>
-                <Td isNumeric>{stats.quartile1.toFixed(2)}</Td>
-                <Td isNumeric>{stats.median.toFixed(2)}</Td>
-                <Td isNumeric>{stats.mean.toFixed(2)}</Td>
-                <Td isNumeric>{stats.quartile3.toFixed(2)}</Td>
-                <Td isNumeric>{stats.maxValue.toFixed(2)}</Td>
+                <Td isNumeric>{props.stats.min.toFixed(2)}</Td>
+                <Td isNumeric>{props.stats.q1.toFixed(2)}</Td>
+                <Td isNumeric>{props.stats.median.toFixed(2)}</Td>
+                <Td isNumeric>{props.stats.mean.toFixed(2)}</Td>
+                <Td isNumeric>{props.stats.q3.toFixed(2)}</Td>
+                <Td isNumeric>{props.stats.max.toFixed(2)}</Td>
               </Tr>
             </Tbody>
           </Table>
 
           <Flex flexDirection="column">
             <Flex justifyContent="center" alignItems="center" gridGap={2}>
-              <IconButton
-                aria-label="increase rect size"
-                isRound
-                colorScheme="black"
-                variant="outline"
-                size="sm"
-                icon={<AiOutlinePlus />}
-                onClick={() => setRectSize(rectSize + 1)}
-              ></IconButton>
-              <Text>{`[ ${rectSize} ]`}</Text>
               <IconButton
                 aria-label="decrease rect size"
                 isRound
@@ -328,6 +222,16 @@ const MapManPlot: React.FC<MapManPlotProps> = (props) => {
                 size="sm"
                 icon={<AiOutlineMinus />}
                 onClick={() => setRectSize(Math.max(1, rectSize - 1))}
+              ></IconButton>
+              <Text>{`[ ${rectSize} ]`}</Text>
+              <IconButton
+                aria-label="increase rect size"
+                isRound
+                colorScheme="black"
+                variant="outline"
+                size="sm"
+                icon={<AiOutlinePlus />}
+                onClick={() => setRectSize(rectSize + 1)}
               ></IconButton>
             </Flex>
             <Text>Adjust Box Size</Text>

--- a/src/pages/plots/plots-home.tsx
+++ b/src/pages/plots/plots-home.tsx
@@ -310,9 +310,13 @@ const PlotsHome: React.FC = () => {
     onClose: onMapManFormClose,
   } = useDisclosure();
 
-  const onMapManFormSubmit: MapManFormSubmitHandler = (values, actions) => {
+  const onMapManFormSubmit: MapManFormSubmitHandler = async (
+    values,
+    actions
+  ) => {
     onMapManFormClose();
-    plotStore.addMapManPlot(values);
+    setTimeout(() => plotStore.addMapManPlot(values), 10);
+
     actions.setSubmitting(false);
   };
 

--- a/src/types/plots.ts
+++ b/src/types/plots.ts
@@ -1,5 +1,6 @@
 import { DataRows } from '@/store/dataframe';
 import { GXPDistanceMethod } from '@/utils/plots/heatmap';
+import { GxpMapManRect, GxpMapManStats } from '@/utils/plots/mapman';
 import { Layout, PlotData } from 'plotly.js';
 
 export type PlotType = 'heatmap' | 'pca' | 'plotly' | 'image' | 'mapman';
@@ -18,14 +19,13 @@ export type GxpMapManColorScale =
   | 'continuous_xy'
   | 'diverging_-xx';
 export interface GxpMapMan extends GxpPlot {
+  rects: GxpMapManRect[];
+  stats: GxpMapManStats;
   template: string;
-  infoTableColumn: string;
-  infoTableColumnSep: string;
   valuesFrom: string;
   colorScale: GxpMapManColorScale;
   colorScaleValueX?: number;
   colorScaleValueY?: number;
-  sample?: string;
 }
 //#endregion
 

--- a/src/utils/plots/mapman.ts
+++ b/src/utils/plots/mapman.ts
@@ -1,0 +1,132 @@
+import { dataTable, infoTable } from '@/store/data-store';
+import {
+  getBlockformat,
+  getCoordinates,
+  getMapManBins,
+  parseXmlData,
+} from './mapman-xml-domparser';
+import * as d3 from 'd3';
+
+export interface GxpMapManBin {
+  bincode: string;
+  x: number;
+  y: number;
+  bformat: string;
+  fnumber: number;
+  geneValues: { [key: string]: number };
+}
+
+export interface GxpMapManRect {
+  geneId: string;
+  x: number;
+  y: number;
+  bin: string;
+  value: number;
+  xOffset: number;
+  yOffset: number;
+}
+
+export interface GxpMapManStats {
+  min: number;
+  q1: number;
+  median: number;
+  mean: number;
+  q3: number;
+  max: number;
+}
+
+export async function createMapManArgs(
+  template: string,
+  infoTableColumn: string,
+  infoTableColumnSep: string,
+  valuesFrom: string,
+  sampleGroup?: string
+): Promise<{ rects: GxpMapManRect[]; stats: GxpMapManStats }> {
+  const INITIALSIZE = 5;
+
+  const [group, sample] = sampleGroup
+    ? sampleGroup.split(dataTable.config.multiHeader)
+    : [undefined, undefined];
+
+  const rectValues =
+    valuesFrom === 'expressionValue' && group && sample
+      ? dataTable.getMapManMeanValues(group, sample)
+      : infoTable.getColumn(valuesFrom);
+
+  const xmlDocument = await parseXmlData(`mapman-templates/${template}.xml`);
+
+  const dataAreas = xmlDocument.querySelectorAll('DataArea');
+
+  const bins: GxpMapManBin[] = [];
+  const values: number[] = [];
+
+  const rects: GxpMapManRect[] = [];
+
+  dataAreas.forEach((dataArea: Element) => {
+    const { x, y } = getCoordinates(dataArea);
+    const { bformat, fnumber } = getBlockformat(dataArea);
+    const mapmanBins = getMapManBins(dataArea);
+    const geneValues: { [key: string]: number } = {};
+
+    const geneIdsArray = infoTable.getGenesForMapManBin(
+      infoTableColumn,
+      infoTableColumnSep,
+      mapmanBins[0].id,
+      mapmanBins[0].recursive
+    );
+
+    let xOffset = 0;
+    let yOffset = 0;
+
+    geneIdsArray.forEach((geneId) => {
+      const value = parseFloat(rectValues[geneId] as string);
+      values.push(value);
+      geneValues[geneId] = value;
+
+      const xValue =
+        bformat === 'x'
+          ? x + (xOffset % fnumber) * INITIALSIZE
+          : x + xOffset * INITIALSIZE;
+      const yValue =
+        bformat === 'y'
+          ? y + (yOffset % fnumber) * INITIALSIZE
+          : y + yOffset * INITIALSIZE;
+
+      rects.push({
+        geneId,
+        bin: mapmanBins[0].id,
+        value,
+        x: xValue,
+        y: yValue,
+        xOffset: bformat === 'x' ? xOffset % fnumber : xOffset,
+        yOffset: bformat === 'y' ? yOffset % fnumber : yOffset,
+      });
+
+      bformat === 'x' ? xOffset++ : yOffset++;
+      if (bformat === 'x' && xOffset != 0 && xOffset % fnumber === 0) {
+        yOffset++;
+      } else if (bformat === 'y' && yOffset != 0 && yOffset % fnumber === 0) {
+        xOffset++;
+      }
+    });
+    bins.push({
+      bincode: mapmanBins[0].id,
+      x,
+      y,
+      bformat,
+      fnumber,
+      geneValues,
+    });
+  });
+  const min = d3.min(values) ?? 0;
+  const q1 = d3.quantile(values, 0.25) ?? 0;
+  const median = d3.median(values) ?? 0;
+  const mean = d3.mean(values) ?? 0;
+  const q3 = d3.quantile(values, 0.75) ?? 0;
+  const max = d3.max(values) ?? 0;
+
+  return {
+    rects,
+    stats: { min, q1, median, mean, q3, max },
+  };
+}


### PR DESCRIPTION
## Summary

This PR implements a refactor on how we render the mapman plots. Instead of recalculating and re-parsing the xml (e.g. when changing pages), the calculation is done separately once when submitting the form. We return an array of rectangles that can directly be bound as data to the svg via d3.

## Changes
- feat: add mapman util; returns rects + stats
- feat: async action in plot-store to push the plot
- feat: add setTimeOut + async to mapmanformsubmit
- feat: add loading temp plot
- refactor: switch adjust box size buttons