### PR TITLE
refactor: Add validation for Numeric column, Add numeric validation function to dataframe, Update Mapman form pass numeric column validation

### DIFF
--- a/src/pages/plots/components/mapman-form.tsx
+++ b/src/pages/plots/components/mapman-form.tsx
@@ -141,7 +141,9 @@ const MapManForm: React.FC<MapManFormProps> = (props) => {
             name="valuesFrom"
             options={infoTable.colNames.reduce(
               (acc, colName) => {
-                acc.push({ value: colName, label: colName });
+                if (infoTable.isNumericColumn(colName)) {
+                  acc.push({ value: colName, label: colName });
+                }
                 return acc;
               },
               [{ value: 'expressionValue', label: 'Mean expression value' }]

--- a/src/pages/tools/components/mapman-tool.tsx
+++ b/src/pages/tools/components/mapman-tool.tsx
@@ -160,27 +160,25 @@ const MapMan: React.FC = () => {
               isClosable: true,
             });
             return;
+          } else {
+            // Parse the input file as a table
+            parseMercatorAndAddToInfoTable(reader.result as string, {
+              addDescription: values.addDescription,
+              addName: values.addName,
+            });
+            toast({
+              title: 'Successfully imported Mercator table',
+              status: 'success',
+              description:
+                'The provided Mercator tabular output was successfully imported into the application.',
+              isClosable: true,
+            });
           }
-
-          // Parse the input file as a table
-          parseMercatorAndAddToInfoTable(reader.result as string, {
-            addDescription: values.addDescription,
-            addName: values.addName,
-          });
         };
-
         reader.onloadend = () => {
           actions.setSubmitting(false);
           onClose();
-          toast({
-            title: 'Successfully imported Mercator table',
-            status: 'success',
-            description:
-              'The provided Mercator tabular output was successfully imported into the application.',
-            isClosable: true,
-          });
         };
-
         reader.onerror = () => {
           actions.setSubmitting(false);
           console.error('There was an error while reading the file');
@@ -236,7 +234,7 @@ const MapMan: React.FC = () => {
               Use the Mercator v4 tool to annotate your genes with MapMan Bins. Clicking here
               will bring you to the plabipd online resources to run Mercator on your DNA or protein
               sequences. After running Mercator you can import the output table into GXP by using
-              the Card below. 
+              the Card below.
             `}
               onClick={() => window.open('https://plabipd.de/portal/mercator4')}
             />

--- a/src/store/dataframe.ts
+++ b/src/store/dataframe.ts
@@ -1,7 +1,7 @@
 import { makeAutoObservable } from 'mobx';
 import { mapFromArrays } from '@/utils/collection';
 import { buildTreeBranches, ArrayTree } from '@/utils/reducers';
-import { isNumeric } from '@/utils/validation';
+import { isNumeric, isParsableAsNumeric } from '@/utils/validation';
 import { setToColors } from '@/utils/color';
 import { mean } from 'd3';
 
@@ -497,5 +497,10 @@ export class Dataframe {
     if (addDescription) {
       this.header.push('MapMan_DESCRIPTION');
     }
+  }
+
+  isNumericColumn(colName: string): boolean {
+    const col10Elm = Object.values(this.getColumn(colName)).slice(0, 9);
+    return col10Elm.every((x) => isParsableAsNumeric(x));
   }
 }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -26,3 +26,19 @@ export function isNullOrUndefined(x: unknown): x is null | undefined {
 export function isNumeric(x: unknown): x is number {
   return typeof x === 'number' && !isNaN(x);
 }
+
+export function isParsableAsNumeric(x: string): boolean {
+  const naValues = [
+    'na',
+    'NA',
+    'N/A',
+    'n/a',
+    null,
+    NaN,
+    'NaN',
+    'nan',
+    'null',
+    '',
+  ];
+  return isNumeric(Number(x)) || naValues.includes(x);
+}


### PR DESCRIPTION
Added check for numeric columns: checks first ten rows (if available), allow for scientific notation (1.3e-12) and allow different "NA" values (   'na', 'NA', 'N/A', 'n/a', null, NaN,  'NaN',  'nan',  'null', '') ignore those cells 