### PR TITLE
feat: Todos 18 nov

### DIFF
--- a/src/components/gene-card/gene-card.tsx
+++ b/src/components/gene-card/gene-card.tsx
@@ -25,6 +25,7 @@ const GeneCard: React.FC<GeneCardProps> = ({ color, accession, geneInfo }) => {
                 w="36"
                 textTransform="uppercase"
                 textColor="yellow.700"
+                wordBreak="break-all"
               >
                 {colName}
               </Flex>

--- a/src/pages/plots/components/color-legend.tsx
+++ b/src/pages/plots/components/color-legend.tsx
@@ -1,21 +1,29 @@
 import React, { useRef, useLayoutEffect } from 'react';
 import * as d3 from 'd3';
 
-interface HeatmapLegendProps {
+interface colorLegendProps {
   colorScale: any;
   id: string;
   minVal: number;
   maxVal: number;
   label: string;
+  width: number;
+  height: number;
+  x: number;
+  y: number;
 }
 
-const HeatmapLegend: React.FC<HeatmapLegendProps> = ({
+const ColorLegend: React.FC<colorLegendProps> = ({
   colorScale,
   id,
   minVal,
   maxVal,
   label,
-}: HeatmapLegendProps) => {
+  width,
+  height,
+  x,
+  y,
+}: colorLegendProps) => {
   const ref = useRef(null);
 
   useLayoutEffect(() => {
@@ -53,22 +61,25 @@ const HeatmapLegend: React.FC<HeatmapLegendProps> = ({
 
     svg
       .append('rect')
-      .attr('width', 20)
-      .attr('height', 250)
-      .attr('x', 120)
-      .attr('y', 60)
+      .attr('width', width)
+      .attr('height', height)
+      .attr('x', x)
+      .attr('y', y)
       .style('fill', `url(#linear-gradient-${id})`);
 
-    svg.append('g').attr('transform', 'translate(110, 60)').call(axis);
+    svg
+      .append('g')
+      .attr('transform', `translate(${x - 10}, ${y})`)
+      .call(axis);
 
     svg
       .append('text')
       .attr('class', 'y label')
       .attr('text-anchor', 'end')
-      .attr('transform', 'translate (100,110) rotate(-90)')
+      .attr('transform', `translate (${x - 20},${y + 80}) rotate(-90)`)
       .text(label);
   }, []);
   return <svg ref={ref} />;
 };
 
-export default HeatmapLegend;
+export default ColorLegend;

--- a/src/pages/plots/components/color-legend.tsx
+++ b/src/pages/plots/components/color-legend.tsx
@@ -71,6 +71,7 @@ const ColorLegend: React.FC<colorLegendProps> = ({
 
     svg
       .append('g')
+      .style('font-size', '1rem')
       .attr('transform', `translate(${x - 10}, ${y})`)
       .call(axis);
 

--- a/src/pages/plots/components/color-legend.tsx
+++ b/src/pages/plots/components/color-legend.tsx
@@ -11,6 +11,7 @@ interface colorLegendProps {
   height: number;
   x: number;
   y: number;
+  reverse?: boolean;
 }
 
 const ColorLegend: React.FC<colorLegendProps> = ({
@@ -23,11 +24,12 @@ const ColorLegend: React.FC<colorLegendProps> = ({
   height,
   x,
   y,
+  reverse,
 }: colorLegendProps) => {
   const ref = useRef(null);
 
   useLayoutEffect(() => {
-    const scale = d3.scaleLinear().domain([minVal, maxVal]).range([250, 0]);
+    const scale = d3.scaleLinear().domain([minVal, maxVal]).range([height, 0]);
     const axis = d3.axisLeft(scale).scale(scale).tickValues([minVal, maxVal]);
 
     const svg = d3.select(ref.current);
@@ -42,9 +44,9 @@ const ColorLegend: React.FC<colorLegendProps> = ({
 
     linearGradient
       .attr('x1', '0%')
-      .attr('y1', '100%')
+      .attr('y1', `${reverse ? '0' : '100'}%`)
       .attr('x2', '0%')
-      .attr('y2', '0%');
+      .attr('y2', `${reverse ? '110' : '0'}%`);
 
     linearGradient
       .selectAll('stop')

--- a/src/pages/plots/components/heatmap-plot.tsx
+++ b/src/pages/plots/components/heatmap-plot.tsx
@@ -25,7 +25,7 @@ import {
   HierarchyPointNode,
 } from '@visx/hierarchy/lib/types';
 
-import HeatmapLegend from '@/pages/plots/components/heatmap-legend';
+import ColorLegend from '@/pages/plots/components/color-legend';
 
 import { nanoid } from 'nanoid';
 
@@ -237,11 +237,15 @@ const HeatmapPlot: React.FC<HeatmapPlotProps> = (props) => {
             height="100%"
             ref={containerRef}
           >
-            <HeatmapLegend
+            <ColorLegend
               colorScale={colorScale}
               id={nanoid()}
               minVal={props.distanceMethod === 'euclidean' ? colorMin : -1}
               maxVal={props.distanceMethod === 'euclidean' ? colorMax : 1}
+              width={20}
+              height={250}
+              x={120}
+              y={60}
               label={
                 props.distanceMethod === 'euclidean'
                   ? 'euclidean distance'

--- a/src/pages/plots/components/heatmap-plot.tsx
+++ b/src/pages/plots/components/heatmap-plot.tsx
@@ -29,8 +29,8 @@ import ColorLegend from '@/pages/plots/components/color-legend';
 
 import { nanoid } from 'nanoid';
 
-const gradient0 = '#f33d15';
-const gradient1 = '#b4fbde';
+const gradient0 = '#b4fbde';
+const gradient1 = '#f33d15';
 // const gradient0 = '#77312f';
 // const gradient1 = '#f33d15';
 // const cool1 = '#122549';
@@ -73,7 +73,7 @@ const HeatmapPlot: React.FC<HeatmapPlotProps> = (props) => {
   const colorMax = max(props.binData, (d) => max(bins(d), count));
   const colorScale =
     props.distanceMethod === 'correlation'
-      ? scaleSequential([-1, 1], interpolateRdBu)
+      ? scaleSequential([1, -1], interpolateRdBu)
       : scaleLinear<string>({
           range: [gradient0, gradient1],
           domain: [colorMin, colorMax],
@@ -246,6 +246,7 @@ const HeatmapPlot: React.FC<HeatmapPlotProps> = (props) => {
               height={250}
               x={120}
               y={60}
+              reverse={props.distanceMethod === 'correlation'}
               label={
                 props.distanceMethod === 'euclidean'
                   ? 'euclidean distance'

--- a/src/pages/plots/components/mapman-form.tsx
+++ b/src/pages/plots/components/mapman-form.tsx
@@ -34,6 +34,7 @@ export interface MapManFormAttributes {
   colorScaleValueX?: number;
   colorScaleValueY?: number;
   sample?: string;
+  plotTitle?: string;
 }
 
 const templates = [
@@ -99,17 +100,27 @@ const MapManForm: React.FC<MapManFormProps> = (props) => {
         sample: dataTable.sampleGroupsAsArray[0],
         colorScaleValueX: 3,
         colorScaleValueY: 3,
+        plotTitle: '',
       }}
       validateOnBlur={false}
       onSubmit={props.onSubmit}
     >
       {(formProps) => (
         <Box as={Form}>
-          <Flex gridGap="1rem" flexDirection={colorScaleFlexDir}>
+          <FormikField
+            controlProps={{
+              as: 'p',
+            }}
+            initialFocusRef={props.initialFocusRef}
+            label="Plot Title"
+            name="plotTitle"
+          />
+          <Flex
+            gridGap="1rem"
+            flexDirection={colorScaleFlexDir}
+            marginTop="2rem"
+          >
             <FormikSelect
-              controlProps={{
-                marginTop: '1rem',
-              }}
               label="MapMan BINCODE column"
               name="infoTableColumn"
               options={infoTable.colNames.map((colName) => ({
@@ -123,7 +134,6 @@ const MapManForm: React.FC<MapManFormProps> = (props) => {
             <FormikField
               controlProps={{
                 as: 'p',
-                marginTop: '1rem',
               }}
               initialFocusRef={props.initialFocusRef}
               label="BINCODE separator"

--- a/src/pages/plots/components/mapman-plot.tsx
+++ b/src/pages/plots/components/mapman-plot.tsx
@@ -21,7 +21,6 @@ import {
   Td,
   TableCaption,
 } from '@chakra-ui/react';
-import { GxpMapManRect, GxpMapManStats } from '@/utils/plots/mapman';
 import ColorLegend from './color-legend';
 import { nanoid } from 'nanoid';
 
@@ -30,10 +29,7 @@ const gradient1 = '#b4fbde';
 
 const INITIALSIZE = 5;
 
-interface MapManPlotProps extends GxpMapMan {
-  rects: GxpMapManRect[];
-  stats: GxpMapManStats;
-}
+type MapManPlotProps = GxpMapMan;
 
 const MapManPlot: React.FC<MapManPlotProps> = (props) => {
   const ref = useRef(null);
@@ -79,18 +75,33 @@ const MapManPlot: React.FC<MapManPlotProps> = (props) => {
 
   useLayoutEffect(() => {
     d3.xml(`mapman-templates/${props.template}.svg`).then((data) => {
+      const viewBoxY = props.plotTitle ? props.height + 30 : props.height;
+
       const svg = d3
         .select(svgRef.current)
         .attr('width', '90%')
         .attr('height', '100%')
         .attr('preserveAspectRatio', 'xMinYMin meet')
-        .attr('viewBox', `0 0 ${props.width + 100} ${props.height}`)
+        // add space (20) for title
+        .attr(
+          'viewBox',
+          `0 ${props.plotTitle ? -30 : 0} ${props.width + 100} ${viewBoxY}`
+        )
         .classed('main-svg', true);
       (svg.node() as any).append(data.documentElement);
       const svgViz = d3
         .select(svgRef.current)
         .append('g')
         .attr('id', 'viz-layer');
+
+      // Title
+      svg
+        .append('text')
+        .attr('x', props.width / 2)
+        .attr('y', 0)
+        .attr('text-anchor', 'middle')
+        .style('font-size', props.height / 25)
+        .text(`${props.plotTitle}`);
 
       const rects = svgViz
         .selectAll('rect')
@@ -180,6 +191,7 @@ const MapManPlot: React.FC<MapManPlotProps> = (props) => {
             x={props.width + 50}
             y={10}
             label={props.valuesFrom}
+            reverse={props.colorScale === 'diverging_-xx'}
           />
         </svg>
         <Flex

--- a/src/pages/plots/plots-home.tsx
+++ b/src/pages/plots/plots-home.tsx
@@ -15,6 +15,7 @@ import {
   AlertIcon,
   AlertTitle,
   AlertDescription,
+  Divider,
   Flex,
   Spinner,
   useDisclosure,
@@ -380,6 +381,8 @@ const PlotsHome: React.FC = () => {
           disabled={!dataAvailable}
         />
 
+        <Divider />
+
         <SidebarButton
           text="Cluster Heatmap"
           icon={FaBurn}
@@ -394,12 +397,14 @@ const PlotsHome: React.FC = () => {
           disabled={!dataAvailable}
         />
 
+        <Divider />
         <SidebarButton
           text="MapMan Function"
           icon={VscGraphScatter}
           onClick={onMapManFormOpen}
           disabled={!dataAvailable}
         />
+        <Divider />
 
         <SidebarButton
           text="Custom figure"

--- a/src/pages/tools/components/gene-browser-card.tsx
+++ b/src/pages/tools/components/gene-browser-card.tsx
@@ -1,5 +1,8 @@
+import { IconButton } from '@chakra-ui/button';
+import Icon from '@chakra-ui/icon';
 import { Box, BoxProps, Flex, Text } from '@chakra-ui/layout';
 import React from 'react';
+import { AiOutlineEye } from 'react-icons/ai';
 
 interface GeneCardProps extends BoxProps {
   color?: string;
@@ -21,16 +24,32 @@ const GeneCard: React.FC<GeneCardProps> = ({
       flexDirection="column"
       {...props}
     >
-      <Text
-        as="h1"
-        color="orange.600"
-        fontWeight="semibold"
-        fontSize="lg"
-        id={accession}
-        marginBottom={2}
-      >
-        {accession}
-      </Text>
+      <Flex alignItems="center" marginBottom={2} gridGap="1rem">
+        <Text
+          as="h1"
+          color="orange.600"
+          fontWeight="semibold"
+          fontSize="lg"
+          id={accession}
+        >
+          {accession}
+        </Text>
+        <Icon
+          aria-label="show tabular transcript expression values"
+          as={AiOutlineEye}
+          w={5}
+          h={5}
+          color="gray.600"
+          onClick={
+            props.onDoubleClick as
+              | React.MouseEventHandler<SVGElement>
+              | undefined
+          }
+          _hover={{
+            color: 'gray.800',
+          }}
+        ></Icon>
+      </Flex>
 
       {geneInfo.size > 0 ? (
         [...geneInfo.entries()].map(([colName, cellValue]) => (

--- a/src/pages/tools/components/mapman-tool.tsx
+++ b/src/pages/tools/components/mapman-tool.tsx
@@ -9,7 +9,7 @@ import { MercatorFormSubmitHandler } from './mercator-form';
 import FormikModal from '@/components/formik-modal';
 
 import MercatorForm from './mercator-form';
-import { dataTable, infoTable } from '@/store/data-store';
+import { dataTable } from '@/store/data-store';
 import {
   Alert,
   AlertDescription,
@@ -18,123 +18,10 @@ import {
 } from '@chakra-ui/alert';
 import { useToast } from '@chakra-ui/toast';
 import CardButton from '@/components/card-button';
-
-/**
- * Sanity check to validate if the expected Mercator headers are present
- * @param table
- */
-export function validateMercator(headerLine: string): boolean {
-  const header = headerLine.split('\t');
-  if (
-    header[0] === 'BINCODE' &&
-    header[1] === 'NAME' &&
-    header[2] === 'IDENTIFIER' &&
-    header[3] === 'DESCRIPTION' &&
-    header[4] === 'TYPE'
-  )
-    return true;
-
-  return false;
-}
-
-/**
- * @param validRowName valid existing identifier of a row in the info/data table
- * @param columns array of columns to add
- * @param colIndex column index to start appending from
- */
-function addMercatorColumns(
-  validRowName: string,
-  columns: string[],
-  colIndex: number
-): void {
-  if (validRowName) {
-    if (!Array.isArray(infoTable.rows[validRowName]))
-      infoTable.rows[validRowName] = [];
-    if (infoTable.rows[validRowName].length <= colIndex)
-      infoTable.rows[validRowName].push(...columns);
-    else {
-      for (let i = colIndex; i < columns.length + colIndex; i++) {
-        infoTable.rows[validRowName][i] += `,${columns[i - colIndex]}`;
-      }
-    }
-  }
-}
-
-/**
- *
- * @param table mercator table parsed as string
- * @param options options which columns to parse and add to the info table
- */
-export function parseMercatorAndAddToInfoTable(
-  table: string, // The File to be parsed as string. infoTable will be passed from the frontend
-  options: { addName: boolean; addDescription: boolean } // options to add columns
-): void {
-  const lines = table.split('\n').map(function (line) {
-    // reader.results of the read file can be parsed at infoTable point
-    return line.split('\t');
-  });
-  const colIndex = infoTable.header.length;
-
-  const fillLength: number =
-    1 + (options.addName ? 1 : 0) + (options.addDescription ? 1 : 0);
-
-  const geneIDIndex: { [key: string]: number } = {};
-  infoTable.hasData
-    ? infoTable.rowNames.forEach((row, i) => {
-        geneIDIndex[row.toLowerCase()] = i;
-      })
-    : dataTable.rowNames.forEach((row, i) => {
-        geneIDIndex[row.toLowerCase()] = i;
-      });
-  const rowNames = infoTable.rowNames.slice();
-
-  infoTable.addMercatorHeaderAndPrepareColumns(
-    options.addName,
-    options.addDescription
-  );
-
-  lines.forEach((mcLine, i) => {
-    // skip the first line
-    if (i === 0) return;
-
-    if (mcLine[0].length !== 0 && mcLine[2].length !== 0) {
-      // Skip lines without a defined BINCODE
-      const mcBin: string = mcLine[0].replace(/[']+/g, ''); // remove extra quotation marks
-      const mcName: string = mcLine[1].replace(/[']+/g, '');
-      const mcGeneId: string = mcLine[2].replace(/[']+/g, ''); // remove extra quotation marks
-      const mcDescription: string = mcLine[3].replace(/[']+/g, '');
-      if (mcGeneId.length !== 0) {
-        const mcColumns = [mcBin];
-        const validGeneIndex = geneIDIndex[mcGeneId];
-        const validRowName = rowNames[validGeneIndex];
-
-        if (options?.addName) {
-          mcColumns.push(mcName);
-        }
-        if (options?.addDescription) {
-          mcColumns.push(mcDescription);
-        }
-        addMercatorColumns(validRowName, mcColumns, colIndex);
-      }
-    }
-  });
-
-  if (infoTable.hasData) {
-    infoTable.rowNames.forEach((rowName) => {
-      if (infoTable.rows[rowName].length < infoTable.header.length) {
-        const lengthDiff =
-          infoTable.header.length - infoTable.rows[rowName].length;
-        infoTable.rows[rowName].push(...Array(lengthDiff).fill(''));
-      }
-    });
-  } else {
-    dataTable.rowNames.forEach((rowName) => {
-      if (!infoTable.rows[rowName]) {
-        infoTable.rows[rowName] = Array(fillLength).fill('');
-      }
-    });
-  }
-}
+import {
+  parseMercatorAndAddToInfoTable,
+  validateMercator,
+} from '@/utils/mercator';
 
 const MapMan: React.FC = () => {
   const refInitialFocus = React.useRef<FocusableElement | null>(null);

--- a/src/store/plot-store.ts
+++ b/src/store/plot-store.ts
@@ -318,6 +318,8 @@ class PlotStore {
           isLoading: false,
           rects: data.rects,
           stats: data.stats,
+          width: data.width,
+          height: data.height,
           ...options,
         };
 

--- a/src/types/plots.ts
+++ b/src/types/plots.ts
@@ -28,6 +28,7 @@ export interface GxpMapMan extends GxpPlot {
   colorScale: GxpMapManColorScale;
   colorScaleValueX?: number;
   colorScaleValueY?: number;
+  plotTitle?: string;
 }
 //#endregion
 

--- a/src/types/plots.ts
+++ b/src/types/plots.ts
@@ -21,6 +21,8 @@ export type GxpMapManColorScale =
 export interface GxpMapMan extends GxpPlot {
   rects: GxpMapManRect[];
   stats: GxpMapManStats;
+  width: number;
+  height: number;
   template: string;
   valuesFrom: string;
   colorScale: GxpMapManColorScale;

--- a/src/utils/mercator.ts
+++ b/src/utils/mercator.ts
@@ -1,0 +1,118 @@
+import { dataTable, infoTable } from '@/store/data-store';
+
+/**
+ * Sanity check to validate if the expected Mercator headers are present
+ * @param table
+ */
+export function validateMercator(headerLine: string): boolean {
+  const header = headerLine.split('\t');
+  if (
+    header[0] === 'BINCODE' &&
+    header[1] === 'NAME' &&
+    header[2] === 'IDENTIFIER' &&
+    header[3] === 'DESCRIPTION' &&
+    header[4] === 'TYPE'
+  )
+    return true;
+
+  return false;
+}
+
+/**
+ * @param validRowName valid existing identifier of a row in the info/data table
+ * @param columns array of columns to add
+ * @param colIndex column index to start appending from
+ */
+function addMercatorColumns(
+  validRowName: string,
+  columns: string[],
+  colIndex: number
+): void {
+  if (validRowName) {
+    if (!Array.isArray(infoTable.rows[validRowName]))
+      infoTable.rows[validRowName] = [];
+    if (infoTable.rows[validRowName].length <= colIndex)
+      infoTable.rows[validRowName].push(...columns);
+    else {
+      for (let i = colIndex; i < columns.length + colIndex; i++) {
+        infoTable.rows[validRowName][i] += `,${columns[i - colIndex]}`;
+      }
+    }
+  }
+}
+
+/**
+ *
+ * @param table mercator table parsed as string
+ * @param options options which columns to parse and add to the info table
+ */
+export function parseMercatorAndAddToInfoTable(
+  table: string, // The File to be parsed as string. infoTable will be passed from the frontend
+  options: { addName: boolean; addDescription: boolean } // options to add columns
+): void {
+  const lines = table.split('\n').map(function (line) {
+    // reader.results of the read file can be parsed at infoTable point
+    return line.split('\t');
+  });
+  const colIndex = infoTable.header.length;
+
+  const fillLength: number =
+    1 + (options.addName ? 1 : 0) + (options.addDescription ? 1 : 0);
+
+  const geneIDIndex: { [key: string]: number } = {};
+  infoTable.hasData
+    ? infoTable.rowNames.forEach((row, i) => {
+        geneIDIndex[row.toLowerCase()] = i;
+      })
+    : dataTable.rowNames.forEach((row, i) => {
+        geneIDIndex[row.toLowerCase()] = i;
+      });
+  const rowNames = infoTable.rowNames.slice();
+
+  infoTable.addMercatorHeaderAndPrepareColumns(
+    options.addName,
+    options.addDescription
+  );
+
+  lines.forEach((mcLine, i) => {
+    // skip the first line
+    if (i === 0) return;
+
+    if (mcLine[0].length !== 0 && mcLine[2].length !== 0) {
+      // Skip lines without a defined BINCODE
+      const mcBin: string = mcLine[0].replace(/[']+/g, ''); // remove extra quotation marks
+      const mcName: string = mcLine[1].replace(/[']+/g, '');
+      const mcGeneId: string = mcLine[2].replace(/[']+/g, ''); // remove extra quotation marks
+      const mcDescription: string = mcLine[3].replace(/[']+/g, '');
+      if (mcGeneId.length !== 0) {
+        const mcColumns = [mcBin];
+        const validGeneIndex = geneIDIndex[mcGeneId];
+        const validRowName = rowNames[validGeneIndex];
+
+        if (options?.addName) {
+          mcColumns.push(mcName);
+        }
+        if (options?.addDescription) {
+          mcColumns.push(mcDescription);
+        }
+        addMercatorColumns(validRowName, mcColumns, colIndex);
+      }
+    }
+  });
+
+  if (infoTable.hasData) {
+    infoTable.rowNames.forEach((rowName) => {
+      if (infoTable.rows[rowName].length < infoTable.header.length) {
+        const lengthDiff =
+          infoTable.header.length - infoTable.rows[rowName].length;
+        infoTable.rows[rowName].push(...Array(lengthDiff).fill(''));
+      }
+    });
+  } else {
+    dataTable.rowNames.forEach((rowName) => {
+      if (!infoTable.rows[rowName]) {
+        infoTable.rows[rowName] = Array(fillLength).fill('');
+      }
+    });
+  }
+}

--- a/src/utils/plots/mapman.ts
+++ b/src/utils/plots/mapman.ts
@@ -41,7 +41,12 @@ export async function createMapManArgs(
   infoTableColumnSep: string,
   valuesFrom: string,
   sampleGroup?: string
-): Promise<{ rects: GxpMapManRect[]; stats: GxpMapManStats }> {
+): Promise<{
+  rects: GxpMapManRect[];
+  stats: GxpMapManStats;
+  width: number;
+  height: number;
+}> {
   const INITIALSIZE = 5;
 
   const [group, sample] = sampleGroup
@@ -54,6 +59,15 @@ export async function createMapManArgs(
       : infoTable.getColumn(valuesFrom);
 
   const xmlDocument = await parseXmlData(`mapman-templates/${template}.xml`);
+  const svgDocument = await parseXmlData(`mapman-templates/${template}.svg`);
+  const width = parseInt(
+    svgDocument.firstElementChild?.attributes.getNamedItem('width')
+      ?.nodeValue ?? '1024'
+  );
+  const height = parseInt(
+    svgDocument.firstElementChild?.attributes.getNamedItem('height')
+      ?.nodeValue ?? '800'
+  );
 
   const dataAreas = xmlDocument.querySelectorAll('DataArea');
 
@@ -128,5 +142,7 @@ export async function createMapManArgs(
   return {
     rects,
     stats: { min, q1, median, mean, q3, max },
+    width,
+    height,
   };
 }


### PR DESCRIPTION
## Summary

This PR implements Todos from the meeting on Nov 18. Namely:

- Make import of Mercator table to the data section
- add an eye icon to the gene browser cards to help the user to open the expression count table
- add a link to the gene browser to the data menu
- add a color legend to the MapMan plots

## Changes

```
refactor: heatmap legend to color legend
- pass x,y values
- feat: add reverse prop to colorlegend
feat: add mercator input load to sidebar
feat: add genebrowser link to sidebar
feat: add dividers to plot sidebar
refactor: add mercator util for parsing
feat: add eyeIcon for detailed tabular view
feat: mapman-plot pass width/height as props
feat: add color-legend to mapman plot
feat: mapman plotTitle prop
fix: reverse heatmap colors / legend
fix: word-break gene caption
```
