### PR TITLE
refactor: enrichment analysis optimizaion

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -23,6 +23,3 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
-Cypress.Commands.add('dataCy', (value) => {
-  return cy.get(`[data-cy=${value}]`);
-});

--- a/src/types/enrichment.ts
+++ b/src/types/enrichment.ts
@@ -24,6 +24,4 @@ export interface EnrichmentExport extends EnrichmentAnalysisOptions {
   rawData: string;
 }
 
-export type SelectorFunction = (
-  rows: (string | number)[][]
-) => (string | number)[][];
+export type SelectorFunction = (rows: { [key: string]: string }) => string[];

--- a/src/utils/fishers-exact-test.ts
+++ b/src/utils/fishers-exact-test.ts
@@ -1,5 +1,7 @@
 import init from '@/utils/gsl/gsl';
 
+const gsl = init();
+
 // Direction:
 // -1 = left, which means a - 1
 // 1 = right, which means a + 1
@@ -27,7 +29,7 @@ function calcHypergeometricPMF(
   c: number,
   d: number
 ): Promise<number> {
-  return init().then((instance: any) =>
+  return gsl.then((instance: any) =>
     instance._gsl_ran_hypergeometric_pdf(a, a + b, c + d, a + c)
   );
 }

--- a/src/workers/enrichment.ts
+++ b/src/workers/enrichment.ts
@@ -1,22 +1,29 @@
-// import { createHeatmapPlot } from '@/utils/plots/heatmap';
-import { DataRows } from '@/store/dataframe';
 import { EnrichmentAnalysisOptions } from '@/types/enrichment';
-import { runEnrichmentAnalysis } from '@/utils/enrichment_analysis';
+import {
+  getContingencyTables,
+  runEnrichment,
+} from '@/utils/enrichment_analysis';
 
 onmessage = async function (
   e: MessageEvent<{
-    dataRows: DataRows;
+    geneIdsTEFpos: Set<string>;
+    geneIdsTEFneg: Set<string>;
+    TEIpayload: { [key: string]: string };
     options: EnrichmentAnalysisOptions;
-    TEFcolIndex: number;
-    TEIcolIndex: number;
   }>
 ) {
-  const { dataRows, TEFcolIndex, TEIcolIndex, options } = e.data;
-  const workerResult = await runEnrichmentAnalysis(
-    dataRows,
-    options,
-    TEFcolIndex,
-    TEIcolIndex
+  const { geneIdsTEFpos, geneIdsTEFneg, TEIpayload, options } = e.data;
+  console.log('on worker... ', e.data);
+  const universe = [...geneIdsTEFpos, ...geneIdsTEFneg];
+  const contingencyTables = getContingencyTables(
+    universe,
+    geneIdsTEFpos,
+    geneIdsTEFneg,
+    TEIpayload,
+    options
   );
-  postMessage(workerResult, undefined as unknown as string);
+  console.log({ contingencyTables });
+  console.log({ c_len: Object.keys(contingencyTables).length });
+  const workerResult = await runEnrichment(contingencyTables);
+  postMessage(workerResult.sort(), undefined as unknown as string);
 };


### PR DESCRIPTION
## Summary

This PR implements some optimizations and refactoring  for the enrichment analysis code.

## Changes
- fix: a bug were we requested the gsl wasm for each matrix extremefication step. Having too many requests crashed the app
- refactor: Calculate trait A pos/neg gene ids before running the analysis. This enables in case of "multinomial" analysis to only run the enrichment test for those trait A positive genes.
- refactor: no longer convert the dataframe to 2d array
- refactor: separate the calculation of the contingency tables out. This enables us to calculated them separately and pass to the enrichment function.

**Note:** With the current setup, in theory it would be pretty straight forward to implement subworkers for the enrichment worker to further optimize the calculations.