### PR TITLE
feat: enrichment filter option

### DIFF
--- a/src/components/formik-area/formik-area.tsx
+++ b/src/components/formik-area/formik-area.tsx
@@ -8,6 +8,7 @@ import {
   VisuallyHidden,
   Textarea,
   TextareaProps,
+  Tooltip,
 } from '@chakra-ui/react';
 import { FocusableElement } from '@chakra-ui/utils';
 
@@ -18,6 +19,7 @@ interface FormikAreaProps extends TextareaProps {
   controlProps?: FormControlProps;
   validate?: FieldValidator;
   initialFocusRef?: React.MutableRefObject<FocusableElement | null>;
+  tooltip?: string;
 }
 
 const FormikArea: React.FC<FormikAreaProps> = ({
@@ -27,6 +29,7 @@ const FormikArea: React.FC<FormikAreaProps> = ({
   name,
   validate,
   initialFocusRef,
+  tooltip,
   ...props
 }) => {
   const [field, meta] = useField({
@@ -45,7 +48,9 @@ const FormikArea: React.FC<FormikAreaProps> = ({
           <FormLabel fontWeight="semibold">{label}</FormLabel>
         </VisuallyHidden>
       ) : (
-        <FormLabel fontWeight="semibold">{label}</FormLabel>
+        <Tooltip label={tooltip} placement="auto">
+          <FormLabel fontWeight="semibold">{label}</FormLabel>
+        </Tooltip>
       )}
       <Textarea
         ref={(ref) => (initialFocusRef ? (initialFocusRef.current = ref) : ref)}

--- a/src/pages/plots/components/plot-container.tsx
+++ b/src/pages/plots/components/plot-container.tsx
@@ -4,6 +4,7 @@ import { Box, Flex, FlexProps, IconButton, Spinner } from '@chakra-ui/react';
 import { getSVGString } from '@/utils/svg';
 import { PlotType } from '@/types/plots';
 import { plotStore } from '@/store/plot-store';
+import { saveAs } from 'file-saver';
 
 interface PlotContainerProps extends FlexProps {
   status: 'idle' | 'loading';

--- a/src/pages/tools/components/enrichment-form.tsx
+++ b/src/pages/tools/components/enrichment-form.tsx
@@ -1,27 +1,12 @@
-import { Formik, Form, FormikHelpers, FieldArray } from 'formik';
+import { Formik, Form, FormikHelpers } from 'formik';
 import React from 'react';
 import FormikField from '@/components/formik-field';
-import {
-  Box,
-  Button,
-  Flex,
-  Divider,
-  VisuallyHidden,
-  Icon,
-  IconButton,
-  InputRightAddon,
-  FormLabel,
-} from '@chakra-ui/react';
-import { FaPlus, FaTrash } from 'react-icons/fa';
+import { Box, Button, Flex, Divider } from '@chakra-ui/react';
 import { FocusableElement } from '@chakra-ui/utils';
 import { TEFSelectorOption, TEISelectorType } from '@/types/enrichment';
 import FormikSelect from '@/components/formik-select';
 import { infoTable } from '@/store/data-store';
 import FormikArea from '@/components/formik-area';
-import FormikAccession from '@/components/formik-accession';
-import { toJS } from 'mobx';
-import { useMemo } from 'react';
-import { isNumericColumn } from '@/utils/validation';
 
 export type EnrichmentFormSubmitHandler = (
   values: EnrichmentAnalysisFormAttributes,
@@ -40,7 +25,7 @@ interface EnrichmentAnalysisFormAttributes {
   TEIselectorValue: string;
   accessions: string[];
   accessionsList: string;
-  valuesFrom: string;
+  filterGeneIds?: string;
 }
 
 export interface EnrichmentFormProps {
@@ -59,21 +44,6 @@ const TEFselectorOptions: TEFSelectorOption[] = [
 ];
 
 const EnrichmentForm: React.FC<EnrichmentFormProps> = (props) => {
-  const valuesFromOptions = useMemo(() => {
-    const slicedColumns = toJS(infoTable.sliceColumns(0, 9));
-
-    return slicedColumns.reduce(
-      (acc, column, i) => {
-        if (isNumericColumn(column)) {
-          const colName = infoTable.colNames[i];
-          acc.push({ value: colName, label: colName });
-        }
-        return acc;
-      },
-      [{ value: 'expressionValue', label: 'Mean expression value' }]
-    );
-  }, []);
-
   return (
     <Formik<EnrichmentAnalysisFormAttributes>
       initialValues={{
@@ -88,7 +58,6 @@ const EnrichmentForm: React.FC<EnrichmentFormProps> = (props) => {
         TEIselectorMulti: 'delimiter',
         TEIselectorType: 'multinomial',
         TEIselectorValue: '',
-        valuesFrom: valuesFromOptions[0].value,
       }}
       validateOnBlur={false}
       onSubmit={props.onSubmit}
@@ -115,184 +84,61 @@ const EnrichmentForm: React.FC<EnrichmentFormProps> = (props) => {
               }}
               label="Test enrichment for"
               name="TEFcolumn"
-              options={valuesFromOptions}
-              // options={infoTable.colNames.map((colName) => ({
-              //   value: colName,
-              //   label: colName,
-              // }))}
+              // options={valuesFromOptions}
+              options={infoTable.colNames.reduce(
+                (acc, colName) => {
+                  acc.push({
+                    value: colName,
+                    label: colName,
+                  });
+                  return acc;
+                },
+                [{ value: 'filterGeneIds', label: 'Filter Gene identifiers' }]
+              )}
               tooltip="Select a column from your gene info table to test enrichment for"
             />
 
-            <FieldArray name="accessions">
-              {(helpers) => (
-                <Box as="fieldset">
-                  <VisuallyHidden as="legend">Genes</VisuallyHidden>
-
-                  <FormLabel as="p" marginTop="1rem" fontWeight="semibold">
-                    Optionally filter genes
-                  </FormLabel>
-
-                  <FormikArea
-                    controlProps={{
-                      marginTop: '1rem',
-                      marginLeft: '.5rem',
-                    }}
-                    focusBorderColor="orange.300"
-                    name="accessionsList"
-                    label="accession"
-                    hideLabel
-                    placeholder="List your gene accessions here, separated by a newline."
-                    isDisabled={formProps.values.accessions.length > 0}
-                  />
-
-                  {formProps.values.accessions &&
-                    formProps.values.accessions.length > 0 &&
-                    formProps.values.accessions.map((accession, index) => (
-                      <FormikAccession
-                        controlProps={{
-                          as: 'p',
-                        }}
-                        groupProps={{
-                          _focusWithin: {
-                            '& > button': {
-                              display: 'inline-flex',
-                            },
-                          },
-                        }}
-                        isRequired
-                        key={index}
-                        label={`Gene Identifier ${index + 1}`}
-                        name={`accessions.${index}`}
-                        rightChildren={
-                          // REMOVE BUTTON
-                          <InputRightAddon
-                            _focusWithin={{
-                              backgroundColor: 'white',
-                            }}
-                            _hover={{
-                              backgroundColor: 'white',
-                            }}
-                            as="span"
-                            padding={0}
-                          >
-                            <IconButton
-                              _focus={{
-                                color: 'red.600',
-                                outline: 'none',
-                              }}
-                              _groupHover={{
-                                color: 'red.600',
-                              }}
-                              aria-label={`Remove ${accession}`}
-                              color="gray.600"
-                              display="flex"
-                              justifyContent="center"
-                              icon={<FaTrash />}
-                              onClick={() => helpers.remove(index)}
-                              size="md"
-                              variant="unstyled"
-                            />
-                          </InputRightAddon>
-                        }
-                      >
-                        {/* INSERT BUTTON */}
-                        <Box
-                          display="none"
-                          color="gray.500"
-                          _groupFocus={{
-                            display: 'inline-flex',
-                          }}
-                          _groupHover={{
-                            display: 'inline-flex',
-                          }}
-                          _focus={{
-                            backgroundColor: 'orange.600',
-                            color: 'white',
-                            outline: 'none',
-                          }}
-                          _hover={{
-                            backgroundColor: 'orange.600',
-                            color: 'white',
-                          }}
-                          alignItems="center"
-                          as="button"
-                          aria-label={`Insert new below`}
-                          backgroundColor="white"
-                          height="1rem"
-                          justifyContent="center"
-                          left="43%"
-                          padding=".75rem"
-                          position="absolute"
-                          rounded="full"
-                          top="28px"
-                          type="button"
-                          width="1rem"
-                          zIndex="popover"
-                          onClick={() => helpers.insert(index + 1, '')}
-                        >
-                          <Icon as={FaPlus} />
-                        </Box>
-                      </FormikAccession>
-                    ))}
-
-                  {/* ADD NEW BUTTON */}
-                  <Button
-                    _focus={{
-                      outline: 'none',
-                      backgroundColor: 'orange.100',
-                    }}
-                    _hover={{
-                      backgroundColor: 'orange.100',
-                    }}
-                    colorScheme="orange"
-                    marginTop=".5rem"
-                    type="button"
-                    onClick={() => {
-                      if (formProps.values.accessions.length === 0) {
-                        helpers.push('');
-                        helpers.push('');
-                      } else {
-                        helpers.push('');
-                      }
-                    }}
-                    variant="ghost"
-                    disabled={formProps.values.accessionsList !== ''}
-                  >
-                    {formProps.values.accessions.length === 0
-                      ? 'Select Genes'
-                      : 'Add Another Genes'}
-                  </Button>
-                </Box>
-              )}
-            </FieldArray>
-
-            <Flex alignItems="center" justifyContent="center">
-              <FormikSelect
+            {formProps.values.TEFcolumn === 'filterGeneIds' ? (
+              <FormikArea
                 controlProps={{
                   marginTop: '1rem',
-                  flexShrink: 3,
-                  marginRight: '1rem',
                 }}
-                label="Selector"
-                name="TEFselector"
-                options={TEFselectorOptions.map((option) => ({
-                  value: option,
-                  label: option,
-                }))}
-                tooltip="Choose a selector function to classify your column values"
+                focusBorderColor="orange.300"
+                name="filterGeneIds"
+                label="Identifier List"
+                placeholder="List your gene identifiers here, separated by a newline."
+                isDisabled={formProps.values.accessions.length > 0}
+                tooltip="List your gene identifiers to filter for enrichment"
               />
+            ) : (
+              <Flex alignItems="center" justifyContent="center">
+                <FormikSelect
+                  controlProps={{
+                    marginTop: '1rem',
+                    flexShrink: 3,
+                    marginRight: '1rem',
+                  }}
+                  label="Selector"
+                  name="TEFselector"
+                  options={TEFselectorOptions.map((option) => ({
+                    value: option,
+                    label: option,
+                  }))}
+                  tooltip="Choose a selector function to classify your column values"
+                />
 
-              <FormikField
-                controlProps={{
-                  as: 'p',
-                  marginTop: '1rem',
-                }}
-                initialFocusRef={props.initialFocusRef}
-                label="Selector Value"
-                name="TEFselectorValue"
-                isRequired
-              />
-            </Flex>
+                <FormikField
+                  controlProps={{
+                    as: 'p',
+                    marginTop: '1rem',
+                  }}
+                  initialFocusRef={props.initialFocusRef}
+                  label="Selector Value"
+                  name="TEFselectorValue"
+                  isRequired
+                />
+              </Flex>
+            )}
 
             <Divider marginTop="1rem" />
 

--- a/src/store/enrichment-store.ts
+++ b/src/store/enrichment-store.ts
@@ -76,28 +76,37 @@ class EnrichmentStore {
       );
     }
 
+    // PLACEHOLDER
     const id = nanoid();
     const pendingEnrichment: EnrichmentAnalysis = {
       id,
       isLoading: true,
       options,
     };
-
     const enrichmentIndex = this.analyses.push(pendingEnrichment) - 1;
 
-    const TEFselectorFunction = getSelectorFunction(
-      options.TEFselector,
-      options.TEFselectorValue
-    );
+    // TEST ENRICHMENT FOR
+    let geneIdsTEFpos = new Set<string>();
+    let geneIdsTEFneg = new Set<string>();
 
-    const TEFcolumn = infoTable.getColumn(options.TEFcolumn);
-    const TEIcolumn = infoTable.getColumn(options.TEIcolumn);
+    if (options.filterGeneIds) geneIdsTEFpos = new Set(options.filterGeneIds);
+    else if (options.TEFselector && options.TEFselectorValue) {
+      const TEFselectorFunction = getSelectorFunction(
+        options.TEFselector,
+        options.TEFselectorValue
+      );
+      const TEFcolumn = infoTable.getColumn(options.TEFcolumn);
+      geneIdsTEFpos = new Set(TEFselectorFunction(TEFcolumn));
+    }
 
-    const geneIdsTEFpos = new Set(TEFselectorFunction(TEFcolumn));
-    const geneIdsTEFneg = new Set(
+    geneIdsTEFneg = new Set(
       Object.keys(infoTable.rows).filter((id) => !geneIdsTEFpos.has(id))
     );
 
+    // TEST ENRICHMENT IN
+    const TEIcolumn = infoTable.getColumn(options.TEIcolumn);
+
+    // START THE WORKER THREAD
     const worker = new EnrichmentWorker();
     worker.postMessage({
       geneIdsTEFpos,

--- a/src/types/enrichment.ts
+++ b/src/types/enrichment.ts
@@ -5,13 +5,13 @@ export type TEISelectorType = 'binary' | 'multinomial';
 export interface EnrichmentAnalysisOptions {
   title: string;
   TEFcolumn: string;
-  TEFselector: TEFSelectorOption;
-  TEFselectorValue: string;
+  TEFselector?: TEFSelectorOption;
+  TEFselectorValue?: string;
   TEIcolumn: string;
   TEIselector: TEISelectorOption;
   TEIselectorType: TEISelectorType;
   TEIselectorValue: string;
-  filterGenes?: string[];
+  filterGeneIds?: string[];
 }
 
 export interface EnrichmentAnalysis {

--- a/src/types/enrichment.ts
+++ b/src/types/enrichment.ts
@@ -11,6 +11,7 @@ export interface EnrichmentAnalysisOptions {
   TEIselector: TEISelectorOption;
   TEIselectorType: TEISelectorType;
   TEIselectorValue: string;
+  filterGenes?: string[];
 }
 
 export interface EnrichmentAnalysis {

--- a/src/workers/enrichment.ts
+++ b/src/workers/enrichment.ts
@@ -13,7 +13,6 @@ onmessage = async function (
   }>
 ) {
   const { geneIdsTEFpos, geneIdsTEFneg, TEIpayload, options } = e.data;
-  console.log('on worker... ', e.data);
   const universe = [...geneIdsTEFpos, ...geneIdsTEFneg];
   const contingencyTables = getContingencyTables(
     universe,
@@ -22,8 +21,6 @@ onmessage = async function (
     TEIpayload,
     options
   );
-  console.log({ contingencyTables });
-  console.log({ c_len: Object.keys(contingencyTables).length });
   const workerResult = await runEnrichment(contingencyTables);
   postMessage(workerResult.sort(), undefined as unknown as string);
 };


### PR DESCRIPTION
## Summary

This PR implements the functionality to optionally, instead of filtering for a specific condition in an info-table column, filter for a list a gene identifiers.

Additionally added functionality to download an enrichment-analysis directly as csv from the UI.

## Changes
- feat: add Tooltip to FormikArea
- fix: correctly import saveAs
- chore: remove debug logs
- feat: funcionality for passing a list of genes to filter
- feat: catch dupliacte enrichment error and show toast notification
- feat: add button to download enrichmnet as CSV

