### PR TITLE
refactor: Gene Identifier labels and placeholder in the plots forms

### DIFF
--- a/src/pages/plots/components/bars-form.tsx
+++ b/src/pages/plots/components/bars-form.tsx
@@ -43,8 +43,8 @@ export interface BarsFormProps {
 const BarsForm: React.FC<BarsFormProps> = (props) => {
   const validateAccession: FieldValidator = (value: string) => {
     const row = dataTable.getRow(value);
-    if (!row) return 'The accession ID does not exist';
-    if (!value) return 'The accession ID cannot be empty';
+    if (!row) return 'The identifier does not exist';
+    if (!value) return 'The identifier cannot be empty';
   };
 
   return (
@@ -120,7 +120,9 @@ const BarsForm: React.FC<BarsFormProps> = (props) => {
                       }}
                       isRequired
                       key={index}
-                      label={`Gene Identifier ${index + 1}`}
+                      label={`Identifier (gene/metabolite/accession) ${
+                        index + 1
+                      }`}
                       name={`accessions.${index}`}
                       rightChildren={
                         formProps.values.accessions.length > 1 && (

--- a/src/pages/plots/components/heatmap-form.tsx
+++ b/src/pages/plots/components/heatmap-form.tsx
@@ -314,7 +314,7 @@ const HeatmapForm: React.FC<HeatmapFormProps> = (props) => {
                     name="accessionsList"
                     label="accession"
                     hideLabel
-                    placeholder="List your gene accessions here, separated by a newline."
+                    placeholder="List your identifiers here, separated by a newline."
                     isDisabled={formProps.values.accessions.length > 0}
                   />
 

--- a/src/pages/plots/components/individual-lines-form.tsx
+++ b/src/pages/plots/components/individual-lines-form.tsx
@@ -43,8 +43,8 @@ export interface IndividualLinesFormProps {
 const IndividualLinesForm: React.FC<IndividualLinesFormProps> = (props) => {
   const validateAccession: FieldValidator = (value: string) => {
     const row = dataTable.getRow(value);
-    if (!row) return 'The accession ID does not exist';
-    if (!value) return 'The accession ID cannot be empty';
+    if (!row) return 'The identifier does not exist';
+    if (!value) return 'The identifier cannot be empty';
   };
 
   return (
@@ -120,7 +120,9 @@ const IndividualLinesForm: React.FC<IndividualLinesFormProps> = (props) => {
                       }}
                       isRequired
                       key={index}
-                      label={`Gene Identifier ${index + 1}`}
+                      label={`Identifier (gene/metabolite/accession) ${
+                        index + 1
+                      }`}
                       name={`accessions.${index}`}
                       rightChildren={
                         formProps.values.accessions.length > 1 && (

--- a/src/pages/plots/components/pca-form.tsx
+++ b/src/pages/plots/components/pca-form.tsx
@@ -278,7 +278,7 @@ const PCAForm: React.FC<PCAFormProps> = (props) => {
                   name="accessionsList"
                   label="accession"
                   hideLabel
-                  placeholder="List your gene accessions here, separated by a newline."
+                  placeholder="List your identifiers here, separated by a newline."
                   isDisabled={formProps.values.accessions.length > 0}
                 />
 

--- a/src/pages/plots/components/stacked-lines-form.tsx
+++ b/src/pages/plots/components/stacked-lines-form.tsx
@@ -45,8 +45,8 @@ export interface StackedLinesFormProps {
 const StackedLinesForm: React.FC<StackedLinesFormProps> = (props) => {
   const validateAccession: FieldValidator = (value: string) => {
     const row = dataTable.getRow(value);
-    if (!row) return 'The accession ID does not exist';
-    if (!value) return 'The accession ID cannot be empty';
+    if (!row) return 'The identifier does not exist';
+    if (!value) return 'The identifier cannot be empty';
   };
 
   return (
@@ -141,7 +141,9 @@ const StackedLinesForm: React.FC<StackedLinesFormProps> = (props) => {
                       }}
                       isRequired
                       key={index}
-                      label={`Gene Identifier ${index + 1}`}
+                      label={`Identifier (gene/metabolite/accession) ${
+                        index + 1
+                      }`}
                       name={`accessions.${index}`}
                       rightChildren={
                         formProps.values.accessions.length > 1 && (


### PR DESCRIPTION
Changes
*  "Gene Identifier 1*"  label in stacked-line, bars and  individual lines forms changed to "(gene/metabolite/accession)" 
*  "The accession ID" does not exist label in stacked-line, bars and individual lines forms changed to "the identifier does not exist" 
*  " List your gene identifiers here, separated by a newline." placeholder in PCA and heatmap form to "List your identifiers here, separated by a newline."